### PR TITLE
Fix html link in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,8 @@ Pull requests are the best way to propose changes to the codebase. We actively w
 In short, when you submit code changes, your submissions are understood to be under the same [Apache License](LICENSE) that covers the project.
 Feel free to contact the maintainers if that's a concern.
 
-## Report bugs using Github's [issues]()
-We use GitHub issues to track public bugs. Report a bug by [opening a new issue](). 
+## Report bugs using Github's [issues](https://github.com/cisco/fledge/issues)
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/cisco/fledge/issues).
 
 ## Write bug reports with detail, background, and sample code
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a few sample examples to explore functionality and workflow of fledge.
 
-The examples here can be executed within [fiab](../../fiab/README.md) environment.
+The examples here can be executed within [fiab](../fiab/README.md) environment.
 
 ## Setup
 `config.yaml` is a configuration file for local fiab environment. Place it in `$HOME/.fledge` folder.


### PR DESCRIPTION
The link to fiab README.md is broken. It is now fixed. In addition,
in CONTRIBUTING.md file the link to github issue is updated.