### PR TITLE
Add imagepullsecrets

### DIFF
--- a/deployment/helm-chart/templates/deployment-controller.yaml
+++ b/deployment/helm-chart/templates/deployment-controller.yaml
@@ -18,6 +18,8 @@ spec:
       #   prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: controller
+      imagePullSecrets:
+      - name: ecr-pull-secret
       containers:
       - name: {{ .Values.servicename }}-controller
         image: "{{ .Values.docker.GeneralFullImagePreamble }}{{ .Values.dimage }}:{{ .Values.tagversion }}"


### PR DESCRIPTION
In order to download image from a private container repository,
imagePullSecrets is required. The necessary entry is added.
Note that the name entry should match the secret's name that stores
credentials for the repository that the controller needs to access.