### PR TITLE
fix: buffered channel for notifer

### DIFF
--- a/cmd/notifier/app/eventroute.go
+++ b/cmd/notifier/app/eventroute.go
@@ -21,6 +21,10 @@ import (
 	pbNotify "github.com/cisco/fledge/pkg/proto/notification"
 )
 
+const (
+	eventChannelLen = 1
+)
+
 // GetEvent is called by the client to subscribe to the notification service.
 // Adds the client to the server client map and stores the client stream.
 func (s *notificationServer) GetEvent(in *pbNotify.AgentInfo, stream pbNotify.EventRoute_GetEventServer) error {
@@ -53,7 +57,7 @@ func (s *notificationServer) getEventChannel(agentId string) chan *pbNotify.Even
 
 	s.mutex.Lock()
 	if _, ok := s.eventQueues[agentId]; !ok {
-		eventCh = make(chan *pbNotify.Event)
+		eventCh = make(chan *pbNotify.Event, eventChannelLen)
 		s.eventQueues[agentId] = eventCh
 	} else {
 		eventCh = s.eventQueues[agentId]

--- a/cmd/notifier/app/triggerroute.go
+++ b/cmd/notifier/app/triggerroute.go
@@ -55,15 +55,15 @@ func (s *notificationServer) Notify(ctx context.Context, in *pbNotify.EventReque
 
 	resp := &pbNotify.Response{
 		Status:       pbNotify.Response_SUCCESS,
-		Message:      "Successfully registered event for all the agents",
+		Message:      "Successfully registered event for all agents",
 		FailedAgents: failedAgents,
 	}
 
 	if len(in.AgentIds) > 0 && len(failedAgents) == len(in.AgentIds) {
-		resp.Message = "Failed to register event all the agents"
+		resp.Message = "Failed to register event for all agents"
 		resp.Status = pbNotify.Response_ERROR
 	} else if len(failedAgents) > 0 && len(failedAgents) < len(in.AgentIds) {
-		resp.Message = "Registered event for some of the agents successfully"
+		resp.Message = "Registered event for some agents successfully"
 		resp.Status = pbNotify.Response_PARTIAL_SUCCESS
 	}
 


### PR DESCRIPTION
non-buffered channel results in failure to register a notification
event when an agent is not ready to read event from the channel.
To fix the issue, a buffered channel with size 1 is used.