### PR TITLE
resource spec update for job

### DIFF
--- a/deployment/fledge-job/job-agent.yaml.mustache
+++ b/deployment/fledge-job/job-agent.yaml.mustache
@@ -24,11 +24,11 @@ spec:
         ports:
         - containerPort: {{ .Values.componentPorts.agent }}
 
-        # TODO: revisit resource request later
-        # resources:
-        #   requests:
-        #     cpu: {{ .Values.resources.cpu }}
-        #     memory: {{ .Values.resources.memory }}
+        resources:
+	  limits:
+	    memory: 2Gi
+          requests:
+            memory: 500Mi
 
         env:
         - name: FLEDGE_AGENT_ID

--- a/deployment/fledge-job/values.yaml
+++ b/deployment/fledge-job/values.yaml
@@ -7,7 +7,3 @@ componentPorts:
   apiserver: "10100"
   notifier: "10101"
   agent: "10103"
-
-resources:
-  cpu: 200m
-  memory: 1Gi


### PR DESCRIPTION
A machine learning (ML) workload tends to need more compute resources.
Especially, memory limit often kicks off OOM, and leads to the
termination of an ML process. If requested memory is too much,
launching the workload can fail too.

This is an attempt to strike a balance between request and limit.
In future, request and limit will be dynamically configurable.