### PR TITLE
fix: yaml format in job spec template

### DIFF
--- a/deployment/fledge-job/job-agent.yaml.mustache
+++ b/deployment/fledge-job/job-agent.yaml.mustache
@@ -25,8 +25,8 @@ spec:
         - containerPort: {{ .Values.componentPorts.agent }}
 
         resources:
-	  limits:
-	    memory: 2Gi
+          limits:
+            memory: 2Gi
           requests:
             memory: 500Mi
 


### PR DESCRIPTION
A tab is used in the job yaml template, which led to YAML parse
error. The error is fixed with the change.