### PR TITLE
fix: configmap

### DIFF
--- a/deployment/helm-chart/templates/configmap.yaml
+++ b/deployment/helm-chart/templates/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
 data:
   controller.yaml: |
     ---
-    db: mongodb://fledge-db:27017
+    db: {{ .Values.database.uri }}
     brokers:
       - sort: mqtt
         host: mqtt.eclipseprojects.io
-    notifier: fledge-notifier:10101
+    notifier: {{ .Values.servicename }}-notifier:{{ .Values.componentPorts.notifier }}
     platform: k8s
     registry: http://mlflow:5000


### PR DESCRIPTION
In configmap, db uri and notifier host are not read from values.yaml.
Instead, they are hard-coded. This is now fixed.