### PR TITLE
add s3 access key info

### DIFF
--- a/deployment/fledge-job/job-agent.yaml.mustache
+++ b/deployment/fledge-job/job-agent.yaml.mustache
@@ -33,5 +33,24 @@ spec:
         env:
         - name: FLEDGE_AGENT_ID
           value: <% agentId %>
+
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: fledge-s3-iam
+              key: AWS_ACCESS_KEY_ID
+
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              name: fledge-s3-iam
+              key: AWS_DEFAULT_REGION
+
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: fledge-s3-iam
+              key: AWS_SECRET_ACCESS_KEY
+
       restartPolicy: Never
 <%={{ }}=%>


### PR DESCRIPTION
In order to use s3 as mlflow's artifact backend, access key info is
needed. Now that access key is provisioned within fledge's namespace,
the key info is set as env variables when pod is brought up.