### PR TITLE
fix: use status code 201 for post api call

### DIFF
--- a/pkg/openapi/apiserver/api_design_schemas_service.go
+++ b/pkg/openapi/apiserver/api_design_schemas_service.go
@@ -73,7 +73,7 @@ func (s *DesignSchemasApiService) CreateDesignSchema(ctx context.Context, user s
 		return openapi.Response(code, nil), err
 	}
 
-	return openapi.Response(http.StatusOK, nil), err
+	return openapi.Response(http.StatusCreated, nil), err
 }
 
 // GetDesignSchema - Get a design schema owned by user

--- a/pkg/openapi/controller/api_design_schemas_service.go
+++ b/pkg/openapi/controller/api_design_schemas_service.go
@@ -55,7 +55,7 @@ func (s *DesignSchemasApiService) CreateDesignSchema(ctx context.Context, user s
 		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("insert design schema details request failed")
 	}
 
-	return openapi.Response(http.StatusOK, nil), nil
+	return openapi.Response(http.StatusCreated, nil), nil
 }
 
 // GetDesignSchema - Get a design schema owned by user


### PR DESCRIPTION
For design schema creation, status code 200 was in use. Instead, code
201 is now returned when a schema is created successfully.