### PR TITLE
fix: improve error handling for design api calls

### DIFF
--- a/cmd/controller/app/database/mongodb/design.go
+++ b/cmd/controller/app/database/mongodb/design.go
@@ -40,6 +40,22 @@ func (db *MongoService) CreateDesign(userId string, design openapi.Design) error
 	return nil
 }
 
+// GetDesign returns the details about the given design id
+func (db *MongoService) GetDesign(userId string, designId string) (openapi.Design, error) {
+	zap.S().Debugf("Get design information for user: %s | desginId: %s", userId, designId)
+
+	var design openapi.Design
+
+	filter := bson.M{util.DBFieldUserId: userId, util.DBFieldId: designId}
+	err := db.designCollection.FindOne(context.TODO(), filter).Decode(&design)
+	if err != nil {
+		err = ErrorCheck(err)
+		zap.S().Errorf("Failed to fetch design template information: %v", err)
+	}
+
+	return design, err
+}
+
 // GetDesigns get a lists of all the designs created by the user
 // TODO: update the method to implement a limit next based cursor
 func (db *MongoService) GetDesigns(userId string, limit int32) ([]openapi.DesignInfo, error) {
@@ -69,20 +85,4 @@ func (db *MongoService) GetDesigns(userId string, limit int32) ([]openapi.Design
 	}
 
 	return designInfoList, nil
-}
-
-// GetDesign returns the details about the given design id
-func (db *MongoService) GetDesign(userId string, designId string) (openapi.Design, error) {
-	zap.S().Debugf("Get design information for user: %s | desginId: %s", userId, designId)
-
-	var design openapi.Design
-
-	filter := bson.M{util.DBFieldUserId: userId, util.DBFieldId: designId}
-	err := db.designCollection.FindOne(context.TODO(), filter).Decode(&design)
-	if err != nil {
-		err = ErrorCheck(err)
-		zap.S().Errorf("Failed to fetch design template information: %v", err)
-	}
-
-	return design, err
 }

--- a/cmd/fledgectl/resources/design/design.go
+++ b/cmd/fledgectl/resources/design/design.go
@@ -73,6 +73,8 @@ func Get(params Params) error {
 	code, responseBody, err := restapi.HTTPGet(url)
 	if err != nil || restapi.CheckStatusCode(code) != nil {
 		fmt.Printf("Failed to retrieve design %s - code: %d, error: %v\n", params.DesignId, code, err)
+		fmt.Printf("response: %s", string(responseBody))
+
 		return nil
 	}
 

--- a/pkg/openapi/apiserver/api_designs_service.go
+++ b/pkg/openapi/apiserver/api_designs_service.go
@@ -60,15 +60,15 @@ func (s *DesignsApiService) CreateDesign(ctx context.Context, user string, desig
 	url := restapi.CreateURL(HostEndpoint, restapi.CreateDesignEndPoint, uriMap)
 
 	// send post request
-	code, _, err := restapi.HTTPPost(url, designInfo, "application/json")
+	code, resp, err := restapi.HTTPPost(url, designInfo, "application/json")
 
 	// response to the user
 	if err != nil {
-		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("create new design request failed")
+		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("%s", string(resp))
 	}
 
 	if err = restapi.CheckStatusCode(code); err != nil {
-		return openapi.Response(code, nil), err
+		return openapi.Response(code, nil), fmt.Errorf("%s", string(resp))
 	}
 
 	return openapi.Response(http.StatusCreated, nil), nil
@@ -87,21 +87,21 @@ func (s *DesignsApiService) GetDesign(ctx context.Context, user string, designId
 	url := restapi.CreateURL(HostEndpoint, restapi.GetDesignEndPoint, uriMap)
 
 	//send get request
-	code, responseBody, err := restapi.HTTPGet(url)
+	code, resp, err := restapi.HTTPGet(url)
 
 	//response to the user
 	if err != nil {
-		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("get design template information request failed")
+		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("%s", string(resp))
 	}
 
 	if err = restapi.CheckStatusCode(code); err != nil {
-		return openapi.Response(code, nil), err
+		return openapi.Response(code, nil), fmt.Errorf("%s", string(resp))
 	}
 
-	resp := openapi.Design{}
-	err = util.ByteToStruct(responseBody, &resp)
+	design := openapi.Design{}
+	err = util.ByteToStruct(resp, &design)
 
-	return openapi.Response(http.StatusOK, resp), err
+	return openapi.Response(http.StatusOK, design), err
 }
 
 // GetDesigns - Get list of all the designs created by the user.
@@ -118,18 +118,19 @@ func (s *DesignsApiService) GetDesigns(ctx context.Context, user string, limit i
 	url := restapi.CreateURL(HostEndpoint, restapi.GetDesignsEndPoint, uriMap)
 
 	//send get request
-	code, responseBody, err := restapi.HTTPGet(url)
+	code, resp, err := restapi.HTTPGet(url)
 
 	//response to the user
 	if err != nil {
-		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("get design template information request failed")
+		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("%s", string(resp))
 	}
 
 	if err = restapi.CheckStatusCode(code); err != nil {
-		return openapi.Response(code, nil), err
+		return openapi.Response(code, nil), fmt.Errorf("%s", string(resp))
 	}
 
-	var resp []openapi.DesignInfo
-	err = util.ByteToStruct(responseBody, &resp)
-	return openapi.Response(http.StatusOK, resp), err
+	designInfoList := []openapi.DesignInfo{}
+	err = util.ByteToStruct(resp, &designInfoList)
+
+	return openapi.Response(http.StatusOK, designInfoList), err
 }


### PR DESCRIPTION
When error is returned after design related api calls, status code is
returned as error, which provide little info on the api call
failures. Now the backend (db error) propagates back to client for
better understanding.