### PR TITLE
make url scheme configurable

### DIFF
--- a/cmd/apiserver/cmd/root.go
+++ b/cmd/apiserver/cmd/root.go
@@ -60,7 +60,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().Uint16P("port", "p", util.ApiServerRestApiPort, "listening port for API server")
 
-	defaultControllerEp := fmt.Sprintf("0.0.0.0:%d", util.ControllerRestApiPort)
+	defaultControllerEp := fmt.Sprintf("http://0.0.0.0:%d", util.ControllerRestApiPort)
 	rootCmd.Flags().StringP("controller", "c", defaultControllerEp, "Controller endpoint")
 	rootCmd.MarkFlagRequired("controller")
 }

--- a/cmd/fledgelet/cmd/root.go
+++ b/cmd/fledgelet/cmd/root.go
@@ -40,7 +40,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if len(strings.Split(apiserver, ":")) != util.NumTokensEndpoint {
+		if len(strings.Split(apiserver, ":")) != util.NumTokensInRestEndpoint {
 			return fmt.Errorf("incorrect format for apiserver endpoint: %s", apiserver)
 		}
 
@@ -48,7 +48,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if len(strings.Split(notifier, ":")) != util.NumTokensEndpoint {
+		if len(strings.Split(notifier, ":")) != util.NumTokensInEndpoint {
 			return fmt.Errorf("incorrect format for notifier endpoint: %s", notifier)
 		}
 
@@ -66,7 +66,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	defaultApiServerEp := fmt.Sprintf("0.0.0.0:%d", util.ApiServerRestApiPort)
+	defaultApiServerEp := fmt.Sprintf("http://0.0.0.0:%d", util.ApiServerRestApiPort)
 	rootCmd.Flags().StringP(argApiserver, "a", defaultApiServerEp, "API server endpoint")
 	rootCmd.MarkFlagRequired(argApiserver)
 

--- a/deployment/fledge-job/job-agent.yaml.mustache
+++ b/deployment/fledge-job/job-agent.yaml.mustache
@@ -17,7 +17,7 @@ spec:
         command: ["/usr/bin/fledgelet"]
         args:
           - "--apiserver"
-          - "{{ .Values.servicename }}-apiserver:{{ .Values.componentPorts.apiserver }}"
+          - "http://{{ .Values.servicename }}-apiserver:{{ .Values.componentPorts.apiserver }}"
           - "--notifier"
           - "{{ .Values.servicename }}-notifier:{{ .Values.componentPorts.notifier }}"
 

--- a/deployment/helm-chart/templates/deployment-apiserver.yaml
+++ b/deployment/helm-chart/templates/deployment-apiserver.yaml
@@ -23,7 +23,7 @@ spec:
         command: ["/usr/bin/apiserver"]
         args:
           - "--controller"
-          - "{{ .Values.servicename }}-controller:{{ .Values.componentPorts.controller }}"
+          - "http://{{ .Values.servicename }}-controller:{{ .Values.componentPorts.controller }}"
         ports:
         - containerPort: {{ .Values.componentPorts.apiserver }}
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -2,5 +2,5 @@
 # place it in $HOME/.fledge folder
 ---
 apiserver:
-  endpoint: 127.0.0.1:10100
+  endpoint: http://127.0.0.1:10100
 user: john

--- a/fiab/docker-compose.yaml
+++ b/fiab/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
   apiserver:
     image: 'fledge'
     container_name: 'fledge-apiserver'
-    command: /usr/bin/apiserver --controller fledge-controller:10102
+    command: /usr/bin/apiserver --controller http://fledge-controller:10102
     ports:
       - '10100:10100'
     depends_on: ['controller']
@@ -81,7 +81,7 @@ services:
     environment:
       FLEDGE_AGENT_ID: bae7fc3f40b9855116865ae8eeaf372189f0afd4
       LOG_LEVEL: DEBUG
-    command: /usr/bin/fledgelet --apiserver fledge-apiserver:10100 --notifier fledge-notifier:10101
+    command: /usr/bin/fledgelet --apiserver http://fledge-apiserver:10100 --notifier fledge-notifier:10101
     ports:
       - '10103:10103'
     depends_on: ['apiserver', 'notifier']
@@ -96,7 +96,7 @@ services:
     environment:
       FLEDGE_AGENT_ID: e49319394d8a641453fcb7b07ba77a62c6f23635
       LOG_LEVEL: DEBUG
-    command: /usr/bin/fledgelet --apiserver fledge-apiserver:10100 --notifier fledge-notifier:10101
+    command: /usr/bin/fledgelet --apiserver http://fledge-apiserver:10100 --notifier fledge-notifier:10101
     ports:
       - '10104:10104'
     depends_on: ['apiserver', 'notifier']
@@ -111,7 +111,7 @@ services:
     environment:
       FLEDGE_AGENT_ID: 3aa26b0e014a4a66f51003add41d53be4a9d2b71
       LOG_LEVEL: DEBUG
-    command: /usr/bin/fledgelet --apiserver fledge-apiserver:10100 --notifier fledge-notifier:10101
+    command: /usr/bin/fledgelet --apiserver http://fledge-apiserver:10100 --notifier fledge-notifier:10101
     ports:
       - '10105:10105'
     depends_on: ['apiserver', 'notifier']

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -124,9 +124,8 @@ func CreateURL(hostEndpoint string, endPoint string, inputMap map[string]string)
 		zap.S().Errorf("error creating a uri. End point: %s", endPoint)
 		return ""
 	}
-	// TODO: change it to https
-	url := "http://" + hostEndpoint + msg
-	return url
+
+	return hostEndpoint + msg
 }
 
 func HTTPPost(url string, msg interface{}, contentType string) (int, []byte, error) {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -68,7 +68,8 @@ const (
 	FilePerm0700 = 0700
 	FilePerm0755 = 0755
 
-	NumTokensEndpoint = 2
+	NumTokensInRestEndpoint = 3
+	NumTokensInEndpoint     = 2
 
 	TaskConfigFile = "config"
 	TaskCodeFile   = "code.zip"


### PR DESCRIPTION
Instead of hard-coding url scheme, make the scheme as part of host
endpoint so that it can be configured.