### PR TITLE
task generation at job creation

### DIFF
--- a/cmd/controller/app/database/db_interfaces.go
+++ b/cmd/controller/app/database/db_interfaces.go
@@ -67,10 +67,11 @@ type JobService interface {
 
 // TaskService is an interface that defines a collection of APIs related to task
 type TaskService interface {
-	CreateTasks([]objects.Task) error
-	DeleteTasks(string) error
+	CreateTasks([]objects.Task, bool) error
+	DeleteTasks(string, bool) error
 	GetTask(string, string) (map[string][]byte, error)
 	UpdateTaskStatus(string, string, openapi.TaskStatus) error
 	IsOneTaskInState(string, openapi.JobState) bool
 	IsOneTaskInStateWithRole(string, openapi.JobState, string) bool
+	SetTaskDirtyFlag(string, bool) error
 }

--- a/cmd/controller/app/database/mongodb/dataset.go
+++ b/cmd/controller/app/database/mongodb/dataset.go
@@ -17,6 +17,7 @@ package mongodb
 
 import (
 	"context"
+	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -74,7 +75,7 @@ func (db *MongoService) GetDatasetById(datasetId string) (openapi.DatasetInfo, e
 	if err != nil {
 		zap.S().Warnf("failed to fetch dataset info: %v", err)
 
-		return openapi.DatasetInfo{}, ErrorCheck(err)
+		return openapi.DatasetInfo{}, fmt.Errorf("dataset %s - %v", datasetId, ErrorCheck(err))
 	}
 
 	return datasetInfo, nil

--- a/cmd/controller/app/job/builder_test.go
+++ b/cmd/controller/app/job/builder_test.go
@@ -111,8 +111,9 @@ var (
 )
 
 func TestGetTaskTemplates(t *testing.T) {
-	builder := newJobBuilder(nil, testJobSpec, nil, config.Registry{})
+	builder := NewJobBuilder(nil, nil, config.Registry{})
 	assert.NotNil(t, builder)
+	builder.jobSpec = &testJobSpec
 
 	builder.schema = testSchema
 	builder.datasets = testDatasets
@@ -127,8 +128,9 @@ func TestGetTaskTemplates(t *testing.T) {
 }
 
 func TestPreCheck(t *testing.T) {
-	builder := newJobBuilder(nil, testJobSpec, nil, config.Registry{})
+	builder := NewJobBuilder(nil, nil, config.Registry{})
 	assert.NotNil(t, builder)
+	builder.jobSpec = &testJobSpec
 
 	builder.schema = testSchema
 	builder.datasets = testDatasets
@@ -145,8 +147,9 @@ func TestPreCheck(t *testing.T) {
 }
 
 func TestIsTemplatesConnected(t *testing.T) {
-	builder := newJobBuilder(nil, testJobSpec, nil, config.Registry{})
+	builder := NewJobBuilder(nil, nil, config.Registry{})
 	assert.NotNil(t, builder)
+	builder.jobSpec = &testJobSpec
 
 	builder.schema = testSchema
 	builder.datasets = testDatasets
@@ -168,8 +171,9 @@ func TestIsTemplatesConnected(t *testing.T) {
 }
 
 func TestIsConverging(t *testing.T) {
-	builder := newJobBuilder(nil, testJobSpec, nil, config.Registry{})
+	builder := NewJobBuilder(nil, nil, config.Registry{})
 	assert.NotNil(t, builder)
+	builder.jobSpec = &testJobSpec
 
 	// success case
 	builder.schema = testSchema
@@ -209,7 +213,9 @@ func TestIsConverging(t *testing.T) {
 }
 
 func TestWalk(t *testing.T) {
-	builder := newJobBuilder(nil, testJobSpec, nil, config.Registry{})
+	builder := NewJobBuilder(nil, nil, config.Registry{})
+	builder.jobSpec = &testJobSpec
+
 	builder.schema = testSchema
 	builder.datasets = testDatasets
 	builder.roleCode = testRoleCode

--- a/cmd/fledgectl/resources/job/job.go
+++ b/cmd/fledgectl/resources/job/job.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cisco/fledge/cmd/fledgectl/resources"
 	"github.com/cisco/fledge/pkg/openapi"
 	"github.com/cisco/fledge/pkg/restapi"
-	"github.com/cisco/fledge/pkg/util"
 )
 
 type Params struct {
@@ -94,17 +93,15 @@ func GetMany(params Params) error {
 	}
 	url := restapi.CreateURL(params.Endpoint, restapi.GetJobsEndPoint, uriMap)
 
-	code, responseBody, err := restapi.HTTPGet(url)
+	code, resp, err := restapi.HTTPGet(url)
 	if err != nil || restapi.CheckStatusCode(code) != nil {
-		var errMsg error
-		_ = util.ByteToStruct(responseBody, &errMsg)
-		fmt.Printf("Failed to retrieve jobs' status - code: %d, error: %v, msg: %v\n", code, err, errMsg)
+		fmt.Printf("Failed to retrieve jobs' status - code: %d, error: %v, msg: %s\n", code, err, string(resp))
 		return nil
 	}
 
 	// convert the response into list of struct
 	infoList := []openapi.JobStatus{}
-	err = json.Unmarshal(responseBody, &infoList)
+	err = json.Unmarshal(resp, &infoList)
 	if err != nil {
 		fmt.Printf("Failed to unmarshal job status: %v\n", err)
 		return nil
@@ -152,9 +149,9 @@ func Update(params Params) error {
 	url := restapi.CreateURL(params.Endpoint, restapi.UpdateJobEndPoint, uriMap)
 
 	// send put request
-	code, _, err := restapi.HTTPPut(url, jobSpec, "application/json")
+	code, resp, err := restapi.HTTPPut(url, jobSpec, "application/json")
 	if err != nil || restapi.CheckStatusCode(code) != nil {
-		fmt.Printf("Failed to update a job - code: %d, error: %v\n", code, err)
+		fmt.Printf("Failed to update a job - code: %d, error: %v, msg: %s\n", code, err, string(resp))
 		return nil
 	}
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -39,17 +39,19 @@ const (
 
 	// Database Fields
 	//TODO append Field to distinguish the fields
-	DBFieldMongoID  = "_id"
-	DBFieldUserId   = "userid"
-	DBFieldId       = "id"
-	DBFieldDesignId = "designid"
-	DBFieldSchemaId = "schemaid"
-	DBFieldJobId    = "jobid"
-	DBFieldAgentId  = "agentid"
-	DBFieldState    = "state"
-	DBFieldRole     = "role"
-	DBFieldTaskType = "type"
-	DBFieldIsPublic = "ispublic"
+	DBFieldMongoID   = "_id"
+	DBFieldUserId    = "userid"
+	DBFieldId        = "id"
+	DBFieldDesignId  = "designid"
+	DBFieldSchemaId  = "schemaid"
+	DBFieldJobId     = "jobid"
+	DBFieldAgentId   = "agentid"
+	DBFieldState     = "state"
+	DBFieldRole      = "role"
+	DBFieldTaskType  = "type"
+	DBFieldIsPublic  = "ispublic"
+	DBFieldTaskDirty = "dirty"
+	DBFieldTimestamp = "timestamp"
 
 	// Port numbers
 	ApiServerRestApiPort  = 10100 // REST API port


### PR DESCRIPTION
Task is now generated during job creation. Also, after job execution,
tasks are not deleted either from DB.
These changes are for supporting user-provided compute use case.

There may be performance penalty (in terms of db size and task
generation time) if a job size is large. This can be investigated in
future.