### PR TITLE
basic task registration/authentication

### DIFF
--- a/api/job_api.partials.yml
+++ b/api/job_api.partials.yml
@@ -369,6 +369,12 @@
         schema:
           type: string
         style: simple
+      - name: key
+        description: A key for task authentication; once the key is recognized by the fledge system for the first time, it can't be changed.
+        in: query
+        required: true
+        schema:
+          type: string
     responses:
       "200":
         content:

--- a/api/job_components.partials.yml
+++ b/api/job_components.partials.yml
@@ -179,6 +179,8 @@ TaskInfo:
       type: string
     type:
       $ref: '#/components/schemas/TaskType'
+    key:
+      type: string
     state:
       $ref: '#/components/schemas/JobState' # reuse job state
     timestamp:

--- a/cmd/controller/app/database/db_interfaces.go
+++ b/cmd/controller/app/database/db_interfaces.go
@@ -62,14 +62,14 @@ type JobService interface {
 	GetJobs(string, int32) ([]openapi.JobStatus, error)
 	UpdateJob(string, string, openapi.JobSpec) error
 	UpdateJobStatus(string, string, openapi.JobStatus) error
-	GetTasksInfo(string, string, int32) ([]openapi.TaskInfo, error)
+	GetTasksInfo(string, string, int32, bool) ([]openapi.TaskInfo, error)
 }
 
 // TaskService is an interface that defines a collection of APIs related to task
 type TaskService interface {
 	CreateTasks([]objects.Task, bool) error
 	DeleteTasks(string, bool) error
-	GetTask(string, string) (map[string][]byte, error)
+	GetTask(string, string, string) (map[string][]byte, error)
 	UpdateTaskStatus(string, string, openapi.TaskStatus) error
 	IsOneTaskInState(string, openapi.JobState) bool
 	IsOneTaskInStateWithRole(string, openapi.JobState, string) bool

--- a/cmd/controller/app/job/handler.go
+++ b/cmd/controller/app/job/handler.go
@@ -240,7 +240,7 @@ func (h *handler) handleStart(event *JobEvent) {
 		return
 	}
 
-	tasksInfo, err := h.dbService.GetTasksInfo(event.Requester, event.JobStatus.Id, 0)
+	tasksInfo, err := h.dbService.GetTasksInfo(event.Requester, event.JobStatus.Id, 0, true)
 	if err != nil {
 		event.ErrCh <- fmt.Errorf("failed to fetch tasks' info: %v", err)
 		return
@@ -367,7 +367,8 @@ func (h *handler) allocateComputes() error {
 		}
 
 		context := map[string]string{
-			"agentId": taskInfo.AgentId,
+			"agentId":  taskInfo.AgentId,
+			"agentKey": taskInfo.Key,
 		}
 		rendered, err := mustache.RenderFile(jobTemplatePath, &context)
 		if err != nil {

--- a/cmd/fledgectl/resources/job/job.go
+++ b/cmd/fledgectl/resources/job/job.go
@@ -60,7 +60,7 @@ func Create(params Params) error {
 	// send post request
 	code, resp, err := restapi.HTTPPost(url, jobSpec, "application/json")
 	if err != nil || restapi.CheckStatusCode(code) != nil {
-		fmt.Printf("Failed to create a job - code: %d, error: %v\n", code, err)
+		fmt.Printf("Failed to create a job - code: %d, error: %v, msg: %s\n", code, err, string(resp))
 		return nil
 	}
 

--- a/cmd/fledgelet/app/service.go
+++ b/cmd/fledgelet/app/service.go
@@ -16,8 +16,6 @@
 package app
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 	"net"
 	"os"
@@ -31,7 +29,8 @@ import (
 )
 
 const (
-	envAgentId = "FLEDGE_AGENT_ID"
+	envAgentId  = "FLEDGE_AGENT_ID"
+	envAgentKey = "FLEDGE_AGENT_KEY"
 )
 
 type AgentService struct {
@@ -51,21 +50,15 @@ func NewAgent(apiserverEp string, notifierEp string) (*AgentService, error) {
 	agentId := os.Getenv(envAgentId)
 	// in case agent id env variable is not set
 	if agentId == "" {
-		// TODO: revisit name and id part;
-		// determining name and id can be done through api call
-		hash := md5.Sum([]byte(name))
-		id := hex.EncodeToString(hash[:])
-
-		if name == "" || id == "" {
-			err := fmt.Errorf("missing fledgelet name or id")
-			zap.S().Error(err)
-			return nil, err
-		}
-
-		agentId = id
+		return nil, fmt.Errorf("agent id not found from env variable %s", envAgentId)
 	}
 
-	tHandler := newTaskHandler(apiserverEp, notifierEp, name, agentId)
+	agentKey := os.Getenv(envAgentKey)
+	if agentKey == "" {
+		return nil, fmt.Errorf("agent key not found from env variable %s", envAgentKey)
+	}
+
+	tHandler := newTaskHandler(apiserverEp, notifierEp, name, agentId, agentKey)
 
 	agent := &AgentService{
 		apiserverEp: apiserverEp,

--- a/cmd/fledgelet/app/taskhandler.go
+++ b/cmd/fledgelet/app/taskhandler.go
@@ -53,6 +53,7 @@ type taskHandler struct {
 	name        string
 	jobId       string
 	agentId     string
+	agentKey    string
 
 	stream pbNotify.EventRoute_GetEventClient
 
@@ -63,12 +64,13 @@ type taskHandler struct {
 	cancel context.CancelFunc
 }
 
-func newTaskHandler(apiserverEp string, notifierEp string, name string, agentId string) *taskHandler {
+func newTaskHandler(apiserverEp string, notifierEp string, name string, agentId string, agentKey string) *taskHandler {
 	return &taskHandler{
 		apiserverEp: apiserverEp,
 		notifierEp:  notifierEp,
 		name:        name,
 		agentId:     agentId,
+		agentKey:    agentKey,
 		state:       openapi.READY,
 	}
 }
@@ -191,6 +193,7 @@ func (t *taskHandler) getTask() ([]string, error) {
 	uriMap := map[string]string{
 		"jobId":   t.jobId,
 		"agentId": t.agentId,
+		"key":     t.agentKey,
 	}
 	url := restapi.CreateURL(t.apiserverEp, restapi.GetTaskEndpoint, uriMap)
 
@@ -212,7 +215,7 @@ func (t *taskHandler) getTask() ([]string, error) {
 
 		filePaths = append(filePaths, filePath)
 
-		zap.S().Infof("Downloaded %s successfully\n", fileName)
+		zap.S().Infof("Downloaded %s successfully", fileName)
 	}
 
 	return filePaths, nil

--- a/deployment/fledge-job/job-agent.yaml.mustache.minikube
+++ b/deployment/fledge-job/job-agent.yaml.mustache.minikube
@@ -37,6 +37,7 @@ spec:
               value: INFO
             - name: FLEDGE_AGENT_ID
               value: <% agentId %>
-
+            - name: FLEDGE_AGENT_KEY
+              value: <% agentKey %>
       restartPolicy: Never
 <%={{ }}=%>

--- a/deployment/fledge-job/job-agent.yaml.mustache.sre
+++ b/deployment/fledge-job/job-agent.yaml.mustache.sre
@@ -34,6 +34,9 @@ spec:
         - name: FLEDGE_AGENT_ID
           value: <% agentId %>
 
+        - name: FLEDGE_AGENT_KEY
+          value: <% agentKey %>
+
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:

--- a/examples/mnist/job.json
+++ b/examples/mnist/job.json
@@ -7,7 +7,7 @@
 	    "default": 1
 	},
 	"fromSystem": [
-	    "61d8dd0a2f9da4fa03629670"
+	    "61e0c1e86bdf29b562de7c22"
 	]
     },
     "priority": "low",

--- a/pkg/openapi/api.go
+++ b/pkg/openapi/api.go
@@ -138,7 +138,7 @@ type JobsApiServicer interface {
 	GetJob(context.Context, string, string) (ImplResponse, error)
 	GetJobStatus(context.Context, string, string) (ImplResponse, error)
 	GetJobs(context.Context, string, int32) (ImplResponse, error)
-	GetTask(context.Context, string, string) (ImplResponse, error)
+	GetTask(context.Context, string, string, string) (ImplResponse, error)
 	GetTasksInfo(context.Context, string, string, int32) (ImplResponse, error)
 	UpdateJob(context.Context, string, string, JobSpec) (ImplResponse, error)
 	UpdateJobStatus(context.Context, string, string, JobStatus) (ImplResponse, error)

--- a/pkg/openapi/api_jobs.go
+++ b/pkg/openapi/api_jobs.go
@@ -225,11 +225,13 @@ func (c *JobsApiController) GetJobs(w http.ResponseWriter, r *http.Request) {
 // GetTask - Get a job task for a given job and agent
 func (c *JobsApiController) GetTask(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	jobId := params["jobId"]
+	query := r.URL.Query()
+	jobIdParam := params["jobId"]
 
-	agentId := params["agentId"]
+	agentIdParam := params["agentId"]
 
-	result, err := c.service.GetTask(r.Context(), jobId, agentId)
+	keyParam := query.Get("key")
+	result, err := c.service.GetTask(r.Context(), jobIdParam, agentIdParam, keyParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		EncodeJSONResponse(err.Error(), &result.Code, w)

--- a/pkg/openapi/apiserver/api_jobs_service.go
+++ b/pkg/openapi/apiserver/api_jobs_service.go
@@ -62,14 +62,12 @@ func (s *JobsApiService) CreateJob(ctx context.Context, user string, jobSpec ope
 
 	// send post request
 	code, resp, err := restapi.HTTPPost(url, jobSpec, "application/json")
-
-	// response to the user
 	if err != nil {
-		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("%s", string(resp))
+		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
 	if err = restapi.CheckStatusCode(code); err != nil {
-		return openapi.Response(code, nil), err
+		return openapi.Response(code, nil), fmt.Errorf("%s", string(resp))
 	}
 
 	// everything went well and response is a job id
@@ -146,16 +144,14 @@ func (s *JobsApiService) GetJobs(ctx context.Context, user string, limit int32) 
 	}
 	url := restapi.CreateURL(HostEndpoint, restapi.GetJobsEndPoint, uriMap)
 
-	//send get request
+	// send get request
 	code, resp, err := restapi.HTTPGet(url)
-
-	// response to the user
 	if err != nil {
-		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("%s", string(resp))
+		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
 	if err = restapi.CheckStatusCode(code); err != nil {
-		return openapi.Response(code, nil), err
+		return openapi.Response(code, nil), fmt.Errorf("%s", string(resp))
 	}
 
 	jobStatusList := []openapi.JobStatus{}
@@ -165,10 +161,15 @@ func (s *JobsApiService) GetJobs(ctx context.Context, user string, limit int32) 
 }
 
 // GetTask - Get a job task for a given job and agent
-func (s *JobsApiService) GetTask(ctx context.Context, jobId string, agentId string) (openapi.ImplResponse, error) {
+func (s *JobsApiService) GetTask(ctx context.Context, jobId string, agentId string, key string) (openapi.ImplResponse, error) {
+	if key == "" {
+		return openapi.Response(http.StatusBadRequest, nil), fmt.Errorf("key can't be empty")
+	}
+
 	uriMap := map[string]string{
 		"jobId":   jobId,
 		"agentId": agentId,
+		"key":     key,
 	}
 	url := restapi.CreateURL(HostEndpoint, restapi.GetTaskEndpoint, uriMap)
 
@@ -194,14 +195,12 @@ func (s *JobsApiService) GetTasksInfo(ctx context.Context, user string, jobId st
 	url := restapi.CreateURL(HostEndpoint, restapi.GetTasksInfoEndpoint, uriMap)
 
 	code, resp, err := restapi.HTTPGet(url)
-
-	// response to the user
 	if err != nil {
-		return openapi.Response(http.StatusInternalServerError, err), fmt.Errorf("%s", string(resp))
+		return openapi.Response(http.StatusInternalServerError, err), err
 	}
 
 	if err = restapi.CheckStatusCode(code); err != nil {
-		return openapi.Response(code, nil), err
+		return openapi.Response(code, nil), fmt.Errorf("%s", string(resp))
 	}
 
 	taskInfoList := []openapi.TaskInfo{}
@@ -224,8 +223,6 @@ func (s *JobsApiService) UpdateJob(ctx context.Context, user string, jobId strin
 
 	// send put request
 	code, resp, err := restapi.HTTPPut(url, jobSpec, "application/json")
-	zap.S().Debugf("code: %d, response: %s, err: %v", code, string(resp), err)
-	// response to the user
 	if err != nil {
 		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
@@ -252,11 +249,11 @@ func (s *JobsApiService) UpdateJobStatus(ctx context.Context, user string, jobId
 	// send put request
 	code, resp, err := restapi.HTTPPut(url, jobStatus, "application/json")
 	if err != nil {
-		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("%s", string(resp))
+		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
 	if err = restapi.CheckStatusCode(code); err != nil {
-		return openapi.Response(code, nil), err
+		return openapi.Response(code, nil), fmt.Errorf("%s", string(resp))
 	}
 
 	return openapi.Response(http.StatusOK, nil), nil
@@ -277,11 +274,11 @@ func (s *JobsApiService) UpdateTaskStatus(ctx context.Context, jobId string, age
 	// send put request
 	code, resp, err := restapi.HTTPPut(url, taskStatus, "application/json")
 	if err != nil {
-		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("%s", string(resp))
+		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
 	if err = restapi.CheckStatusCode(code); err != nil {
-		return openapi.Response(code, nil), err
+		return openapi.Response(code, nil), fmt.Errorf("%s", string(resp))
 	}
 
 	return openapi.Response(http.StatusOK, nil), nil

--- a/pkg/openapi/controller/api_jobs_service.go
+++ b/pkg/openapi/controller/api_jobs_service.go
@@ -151,8 +151,12 @@ func (s *JobsApiService) GetJobs(ctx context.Context, user string, limit int32) 
 }
 
 // GetTask - Get a job task for a given job and agent
-func (s *JobsApiService) GetTask(ctx context.Context, jobId string, agentId string) (openapi.ImplResponse, error) {
-	taskMap, err := s.dbService.GetTask(jobId, agentId)
+func (s *JobsApiService) GetTask(ctx context.Context, jobId string, agentId string, key string) (openapi.ImplResponse, error) {
+	if key == "" {
+		return openapi.Response(http.StatusBadRequest, nil), fmt.Errorf("key can't be empty")
+	}
+
+	taskMap, err := s.dbService.GetTask(jobId, agentId, key)
 	if err != nil {
 		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("failed to get task")
 	}
@@ -162,7 +166,7 @@ func (s *JobsApiService) GetTask(ctx context.Context, jobId string, agentId stri
 
 // GetTasksInfo - Get the info of tasks in a job
 func (s *JobsApiService) GetTasksInfo(ctx context.Context, user string, jobId string, limit int32) (openapi.ImplResponse, error) {
-	tasksInfo, err := s.dbService.GetTasksInfo(user, jobId, limit)
+	tasksInfo, err := s.dbService.GetTasksInfo(user, jobId, limit, false)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to get info of all tasks in a job %s: %v", jobId, err)
 		zap.S().Debug(errMsg)

--- a/pkg/openapi/model_task_info.go
+++ b/pkg/openapi/model_task_info.go
@@ -38,6 +38,8 @@ type TaskInfo struct {
 
 	Type TaskType `json:"type,omitempty"`
 
+	Key string `json:"key,omitempty"`
+
 	State JobState `json:"state,omitempty"`
 
 	Timestamp time.Time `json:"timestamp,omitempty"`

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -104,7 +104,7 @@ var URI = map[string]string{
 	UpdateJobStatusEndPoint: "/{{.user}}/jobs/{{.jobId}}/status",
 
 	// Task
-	GetTaskEndpoint:          "/jobs/{{.jobId}}/{{.agentId}}/task",
+	GetTaskEndpoint:          "/jobs/{{.jobId}}/{{.agentId}}/task/?key={{.key}}",
 	UpdateTaskStatusEndPoint: "/jobs/{{.jobId}}/{{.agentId}}/task/status",
 }
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -51,6 +51,7 @@ const (
 	DBFieldTaskType  = "type"
 	DBFieldIsPublic  = "ispublic"
 	DBFieldTaskDirty = "dirty"
+	DBFieldTaskKey   = "key"
 	DBFieldTimestamp = "timestamp"
 
 	// Port numbers

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
@@ -28,6 +29,14 @@ import (
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+const (
+	runes = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 /*InitZapLog Zap Logger initialization
 
@@ -169,4 +178,23 @@ func CopyFile(src string, dst string) error {
 	}
 
 	return out.Close()
+}
+
+func RandString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = runes[rand.Intn(len(runes))]
+	}
+
+	return string(b)
+}
+
+func Contains(haystack []string, needle string) bool {
+	for i := range haystack {
+		if needle == haystack[i] {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
In case of user-provided compute, there is risk that agent id can be
leaked. To mitigate potential security issue, user can register a
unique key when he launches a task for the first time with an agent id
provided. User must use the key every time he participates in the same
job. The key can't be modified.

For system-provided compute, the key is auto-generated and configured
during compute provisioning (e.g., during k8s pod instantiation).