### PR TITLE
event-driven job progress monitoring

### DIFF
--- a/cmd/controller/app/database/db_interfaces.go
+++ b/cmd/controller/app/database/db_interfaces.go
@@ -16,6 +16,7 @@
 package database
 
 import (
+	"context"
 	"os"
 
 	"github.com/cisco/fledge/cmd/controller/app/objects"
@@ -74,4 +75,5 @@ type TaskService interface {
 	IsOneTaskInState(string, openapi.JobState) bool
 	IsOneTaskInStateWithRole(string, openapi.JobState, string) bool
 	SetTaskDirtyFlag(string, bool) error
+	MonitorTasks(string) (chan openapi.TaskInfo, chan error, context.CancelFunc, error)
 }

--- a/cmd/controller/app/database/mongodb/watcher.go
+++ b/cmd/controller/app/database/mongodb/watcher.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2022 Cisco Systems, Inc. and its affiliates
+// All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodb
+
+import (
+	"context"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.uber.org/zap"
+)
+
+const (
+	errChannelLen = 2
+)
+
+type streamWatcher struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	coll     *mongo.Collection
+	pipeline mongo.Pipeline
+	opts     *options.ChangeStreamOptions
+
+	streamCh chan bson.M
+	errCh    chan error
+}
+
+func (db *MongoService) newstreamWatcher(coll *mongo.Collection, pipeline mongo.Pipeline, opts *options.ChangeStreamOptions,
+	chanLen int) *streamWatcher {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &streamWatcher{
+		ctx:    ctx,
+		cancel: cancel,
+
+		coll:     coll,
+		pipeline: pipeline,
+		opts:     opts,
+
+		streamCh: make(chan bson.M, chanLen),
+		errCh:    make(chan error, errChannelLen),
+	}
+}
+
+func (sw *streamWatcher) watch() error {
+	changeStream, err := sw.coll.Watch(sw.ctx, sw.pipeline, sw.opts)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		defer changeStream.Close(sw.ctx)
+
+		zap.S().Debug("Started watcher")
+
+		for changeStream.Next(sw.ctx) {
+			var event bson.M
+			if err := changeStream.Decode(&event); err != nil {
+				zap.S().Debugf("Failed to decode event: %v", err)
+
+				sw.errCh <- err
+				break
+			}
+
+			// push the event to a stream channel
+			sw.streamCh <- event
+		}
+
+		if err := changeStream.Err(); err != nil {
+			// if the error is not because of context cancellation, send the error
+			if !strings.Contains(err.Error(), context.Canceled.Error()) {
+				sw.errCh <- err
+				zap.S().Debugf("Error on change stream: %v", err)
+			}
+		}
+
+		zap.S().Debug("Finished watcher")
+	}()
+
+	return nil
+}

--- a/cmd/controller/app/deployer/k8s.go
+++ b/cmd/controller/app/deployer/k8s.go
@@ -64,11 +64,7 @@ func (deployer *K8sDeployer) Initialize(clusterName string, namespace string) er
 
 	actionConfig := new(action.Configuration)
 
-	logger := func(format string, v ...interface{}) {
-		zap.S().Debugf(format, v)
-	}
-
-	err = actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), logger)
+	err = actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), zap.S().Debugf)
 	if err != nil {
 		return err
 	}

--- a/cmd/fledgelet/app/taskhandler.go
+++ b/cmd/fledgelet/app/taskhandler.go
@@ -368,15 +368,19 @@ func (t *taskHandler) runTask() {
 	cmd.Stdout = file
 	cmd.Stderr = file
 
+	zap.S().Infof("Starting task for job %s", t.jobId)
+	// set running state in advance
+	// this is for keeping state transition simple, meaning that fledgelet always
+	// set running state first before making transition to one of three states
+	// -- failed, terminated, completed
+	t.updateTaskStatus(openapi.RUNNING)
+
 	err = cmd.Start()
 	if err != nil {
 		zap.S().Errorf("Failed to start task: %v", err)
 		t.updateTaskStatus(openapi.FAILED)
 		return
 	}
-
-	zap.S().Infof("Started task for job %s successfully", t.jobId)
-	t.updateTaskStatus(openapi.RUNNING)
 
 	err = cmd.Wait()
 	if err != nil {


### PR DESCRIPTION
A db watcher is implemented by using Mongodb's stream change feature.
With the watcher, now job progress monitoring is event-driven based on
task status update from fledgelet. Previously, the monitoring was
polling based. The polling-based approach introduced a bug that causes
state deadlock.