### PR TITLE
make image configurable

### DIFF
--- a/build/Imagefile
+++ b/build/Imagefile
@@ -1,6 +1,6 @@
 FROM fledge:base as base-build
 
-FROM containers.cisco.com/research/dl-docker:latest-cpu
+FROM containers.cisco.com/eti-sre/sre-python-docker:latest
 
 # Copy fledge binaries
 COPY --from=base-build /fledge/ /usr/bin/

--- a/build/build-docker.sh
+++ b/build/build-docker.sh
@@ -122,6 +122,7 @@ echo BUILDING DOCKER ${DOCKER_IMAGE}
 docker build --no-cache -t ${DOCKER_IMAGE} -f build/Imagefile .
 
 # Create fledge worker images
+WORKER_IMAGE_NAME=flegde-worker
 # FRAMEWORKS=(allinone pytorch tensorflow)
 # RESOURCES=(cpu gpu)
 FRAMEWORKS=(allinone)
@@ -130,7 +131,7 @@ for framework in ${FRAMEWORKS[@]}; do
     for resource in ${RESOURCES[@]}; do
         target=${framework}-${resource}
         docker build \
-               -t fledge-worker:${target} \
+               -t ${WORKER_IMAGE_NAME}:{target} \
                -f build/WorkerImagefile \
                --build-arg TARGETIMAGE=${target} .
     done

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -31,11 +31,10 @@ import (
 type Controller struct {
 	dbUri     string
 	notifier  string
-	brokers   []config.Broker
-	registry  config.Registry
 	restPort  string
 	platform  string
 	dbService database.DBService
+	jobParams config.JobParams
 
 	jobEventQ  *job.EventQ
 	jobBuilder *job.JobBuilder
@@ -53,7 +52,7 @@ func NewController(cfg *config.Config) (*Controller, error) {
 		return nil, fmt.Errorf("failed to create a job event queue")
 	}
 
-	jobBuilder := job.NewJobBuilder(dbService, cfg.Brokers, cfg.Registry)
+	jobBuilder := job.NewJobBuilder(dbService, cfg.JobParams)
 	if jobBuilder == nil {
 		return nil, fmt.Errorf("failed to create a job builder")
 	}
@@ -61,11 +60,10 @@ func NewController(cfg *config.Config) (*Controller, error) {
 	instance := &Controller{
 		dbUri:     cfg.Db,
 		notifier:  cfg.Notifier,
-		registry:  cfg.Registry,
-		brokers:   cfg.Brokers,
 		restPort:  cfg.Port,
 		platform:  cfg.Platform,
 		dbService: dbService,
+		jobParams: cfg.JobParams,
 
 		jobEventQ:  jobEventQ,
 		jobBuilder: jobBuilder,
@@ -75,7 +73,7 @@ func NewController(cfg *config.Config) (*Controller, error) {
 }
 
 func (c *Controller) Start() {
-	jobMgr, err := job.NewManager(c.dbService, c.jobEventQ, c.notifier, c.brokers, c.registry, c.platform)
+	jobMgr, err := job.NewManager(c.dbService, c.jobEventQ, c.notifier, c.jobParams, c.platform)
 	if err != nil {
 		zap.S().Fatalf("Failed to create a job manager: %v", err)
 	}

--- a/cmd/controller/app/job/builder.go
+++ b/cmd/controller/app/job/builder.go
@@ -45,19 +45,17 @@ const (
 type JobBuilder struct {
 	dbService database.DBService
 	jobSpec   *openapi.JobSpec
-	brokers   []config.Broker
-	registry  config.Registry
+	jobParams config.JobParams
 
 	schema   openapi.DesignSchema
 	datasets []openapi.DatasetInfo
 	roleCode map[string][]byte
 }
 
-func NewJobBuilder(dbService database.DBService, brokers []config.Broker, registry config.Registry) *JobBuilder {
+func NewJobBuilder(dbService database.DBService, jobParams config.JobParams) *JobBuilder {
 	return &JobBuilder{
 		dbService: dbService,
-		brokers:   brokers,
-		registry:  registry,
+		jobParams: jobParams,
 		datasets:  make([]openapi.DatasetInfo, 0),
 	}
 }
@@ -174,7 +172,7 @@ func (b *JobBuilder) getTaskTemplates() ([]string, map[string]*taskTemplate) {
 		template := &taskTemplate{}
 		JobConfig := &template.JobConfig
 
-		JobConfig.Configure(b.jobSpec, b.brokers, b.registry, role, b.schema.Channels)
+		JobConfig.Configure(b.jobSpec, b.jobParams.Brokers, b.jobParams.Registry, role, b.schema.Channels)
 
 		template.isDataConsumer = role.IsDataConsumer
 		if role.IsDataConsumer {

--- a/cmd/controller/app/job/builder_test.go
+++ b/cmd/controller/app/job/builder_test.go
@@ -111,7 +111,7 @@ var (
 )
 
 func TestGetTaskTemplates(t *testing.T) {
-	builder := NewJobBuilder(nil, nil, config.Registry{})
+	builder := NewJobBuilder(nil, config.JobParams{})
 	assert.NotNil(t, builder)
 	builder.jobSpec = &testJobSpec
 
@@ -128,7 +128,7 @@ func TestGetTaskTemplates(t *testing.T) {
 }
 
 func TestPreCheck(t *testing.T) {
-	builder := NewJobBuilder(nil, nil, config.Registry{})
+	builder := NewJobBuilder(nil, config.JobParams{})
 	assert.NotNil(t, builder)
 	builder.jobSpec = &testJobSpec
 
@@ -147,7 +147,7 @@ func TestPreCheck(t *testing.T) {
 }
 
 func TestIsTemplatesConnected(t *testing.T) {
-	builder := NewJobBuilder(nil, nil, config.Registry{})
+	builder := NewJobBuilder(nil, config.JobParams{})
 	assert.NotNil(t, builder)
 	builder.jobSpec = &testJobSpec
 
@@ -171,7 +171,7 @@ func TestIsTemplatesConnected(t *testing.T) {
 }
 
 func TestIsConverging(t *testing.T) {
-	builder := NewJobBuilder(nil, nil, config.Registry{})
+	builder := NewJobBuilder(nil, config.JobParams{})
 	assert.NotNil(t, builder)
 	builder.jobSpec = &testJobSpec
 
@@ -213,7 +213,7 @@ func TestIsConverging(t *testing.T) {
 }
 
 func TestWalk(t *testing.T) {
-	builder := NewJobBuilder(nil, nil, config.Registry{})
+	builder := NewJobBuilder(nil, config.JobParams{})
 	builder.jobSpec = &testJobSpec
 
 	builder.schema = testSchema

--- a/cmd/controller/app/job/handler.go
+++ b/cmd/controller/app/job/handler.go
@@ -54,8 +54,7 @@ type handler struct {
 	jobQueues map[string]*EventQ
 	mu        *sync.Mutex
 	notifier  string
-	brokers   []config.Broker
-	registry  config.Registry
+	jobParams config.JobParams
 	platform  string
 
 	jobSpec openapi.JobSpec
@@ -77,7 +76,7 @@ type handler struct {
 }
 
 func NewHandler(dbService database.DBService, jobId string, eventQ *EventQ, jobQueues map[string]*EventQ, mu *sync.Mutex,
-	notifier string, brokers []config.Broker, registry config.Registry, platform string) (*handler, error) {
+	notifier string, jobParams config.JobParams, platform string) (*handler, error) {
 	// start task monitoring
 	tskEventCh, errCh, tskWatchCancelFn, err := dbService.MonitorTasks(jobId)
 	if err != nil {
@@ -91,8 +90,7 @@ func NewHandler(dbService database.DBService, jobId string, eventQ *EventQ, jobQ
 		jobQueues: jobQueues,
 		mu:        mu,
 		notifier:  notifier,
-		brokers:   brokers,
-		registry:  registry,
+		jobParams: jobParams,
 		platform:  platform,
 		tasksInfo: make([]openapi.TaskInfo, 0),
 		roles:     make([]openapi.Role, 0),
@@ -445,6 +443,7 @@ func (h *handler) allocateComputes() error {
 		}
 
 		context := map[string]string{
+			"imageLoc": h.jobParams.Image,
 			"agentId":  taskInfo.AgentId,
 			"agentKey": taskInfo.Key,
 		}

--- a/cmd/controller/config/config.go
+++ b/cmd/controller/config/config.go
@@ -26,12 +26,18 @@ import (
 )
 
 type Config struct {
-	Db       string   `yaml:"db"`
+	Db       string `yaml:"db"`
+	Notifier string `yaml:"notifier"`
+	Platform string `yaml:"platform,omitempty"`
+	Port     string `yaml:"port,omitempty"`
+
+	JobParams JobParams `yaml:"jobParams"`
+}
+
+type JobParams struct {
 	Brokers  []Broker `yaml:"brokers"`
-	Notifier string   `yaml:"notifier"`
-	Platform string   `yaml:"platform,omitempty"`
-	Port     string   `yaml:"port,omitempty"`
 	Registry Registry `yaml:"registry,omitempty"`
+	Image    string   `yaml:"image"`
 }
 
 type Broker struct {

--- a/deployment/fledge-job/job-agent.yaml.mustache.minikube
+++ b/deployment/fledge-job/job-agent.yaml.mustache.minikube
@@ -19,7 +19,7 @@ spec:
             - "--notifier"
             - "{{ .Values.servicename }}-notifier:{{ .Values.componentPorts.notifier }}"
           command: ["/usr/bin/fledgelet"]
-          image: "{{ .Values.dimage }}:{{ .Values.tagversion }}"
+          image: <% imageLoc %>
           imagePullPolicy: IfNotPresent
           name: {{ .Values.servicename }}-agent-<% agentId %>
 

--- a/deployment/fledge-job/job-agent.yaml.mustache.sre
+++ b/deployment/fledge-job/job-agent.yaml.mustache.sre
@@ -13,7 +13,7 @@ spec:
       - name: ecr-pull-secret
       containers:
       - name: {{ .Values.servicename }}-agent-<% agentId %>
-        image: "{{ .Values.generalFullImagePreamble }}{{ .Values.dimage }}:{{ .Values.tagversion }}"
+        image: <% imageLoc %>
         command: ["/usr/bin/fledgelet"]
         args:
           - "--apiserver"

--- a/deployment/fledge-job/values.yaml
+++ b/deployment/fledge-job/values.yaml
@@ -1,7 +1,3 @@
-generalFullImagePreamble: 626007623524.dkr.ecr.us-east-2.amazonaws.com/
-dimage: fledge
-tagversion: latest
-
 servicename: fledge
 componentPorts:
   apiserver: "10100"

--- a/deployment/helm-chart/templates/configmap.yaml
+++ b/deployment/helm-chart/templates/configmap.yaml
@@ -6,12 +6,14 @@ metadata:
 data:
   controller.yaml: |
     ---
-    brokers:
-      - sort: {{ .Values.broker.sort }}
-        host: {{ .Values.broker.host }}
     db: {{ .Values.database.uri }}
     notifier: {{ .Values.servicename }}-notifier:{{ .Values.componentPorts.notifier }}
     platform: k8s
-    registry:
-      sort: {{ .Values.registry.sort }}
-      uri: {{ .Values.registry.uri }}
+    jobParams:
+      image: {{ .Values.workerImage.preamble }}{{ .Values.workerImage.name }}:{{ .Values.workerImage.tag }}
+      brokers:
+        - sort: {{ .Values.broker.sort }}
+          host: {{ .Values.broker.host }}
+      registry:
+        sort: {{ .Values.registry.sort }}
+        uri: {{ .Values.registry.uri }}

--- a/deployment/helm-chart/values.yaml
+++ b/deployment/helm-chart/values.yaml
@@ -46,6 +46,11 @@ database:
   name: fledge
   uri: mongodb://fledge-mongodb-dev-headless.fledge-dev-blue:27017
 
+workerImage:
+  preamble: 626007623524.dkr.ecr.us-east-2.amazonaws.com/
+  name: fledge-worker
+  tag: allinone-cpu
+
 broker:
   sort: mqtt
   host: broker.hivemq.com

--- a/fiab/README.md
+++ b/fiab/README.md
@@ -78,13 +78,30 @@ Get "https://registry-1.docker.io/v2/": dial tcp: lookup registry-1.docker.io on
 The error might be because of [this issue](https://github.com/kubernetes/minikube/issues/3036).
 If minikube is running on a machine with dnscrypt-proxy or dnsmasq, 
 refer to [here](https://gist.github.com/rscottwatson/e0e3c890b3d4aa81e46bf2993e3e216f) for more details.
-Especially, in case of dnscrypt-proxy, the workaround below is useful.
-Please run the following commands:
+Especially, in case of dnscrypt-proxy, the following workaround is applied.
+
+First, log into the minikube vm with the following command.
 ```
-minikube ssh sudo resolvectl dns eth0 8.8.8.8 8.8.4.4
-minikube ssh sudo resolvectl dns docker0 8.8.8.8 8.8.4.4
-minikube ssh sudo resolvectl dns sit0 8.8.8.8 8.8.4.4
+minikube ssh
 ```
+After logging into the vm, become a super user with the following command.
+```
+sudo su -
+```
+Now run the following:
+```
+cat << EOF >  /var/lib/boot2docker/bootlocal.sh
+echo "DNS=8.8.8.8" >> /etc/systemd/resolved.conf 
+systemctl restart systemd-resolved
+EOF
+chmod 755  /var/lib/boot2docker/bootlocal.sh
+```
+
+To apply the change, run the following after getting out of the minikube vm:
+```
+minikube stop && minikube start
+```
+**Note**: restarting the minikube vm may take a while. If the command hangs, press `Ctrl-C` and rerun the command.
 
 ## Starting fledge
 Open a new terminal window and start the minikube tunnel with the following command:

--- a/fiab/helm-chart/templates/controller-configmap.yaml
+++ b/fiab/helm-chart/templates/controller-configmap.yaml
@@ -7,12 +7,14 @@ metadata:
 data:
   controller.yaml: |
     ---
-    brokers:
-      - sort: mqtt
-        host: mosquitto
     db: mongodb://fledge-mongodb-headless:27017/?replicaSet=rs0
     notifier: fledge-notifier:10101
     platform: k8s
-    registry:
-      sort: mlflow
-      uri: http://mlflow:5000
+    jobParams:
+      image: fledge:latest
+      brokers:
+        - sort: mqtt
+          host: mosquitto
+      registry:
+        sort: mlflow
+        uri: http://mlflow:5000


### PR DESCRIPTION
image is now specified as a controller's config parameter. The
specified image is used when a job is scheduled.

A future plan is to provide a set of images so that the controller can
dynamically choose images depending on resource availability (e.g.,
cpu, gpu, etc) of nodes in a cluster.

minikube dns issue resolution was reverted to a previous version
because the newer resolution causes domain name resolution failure in
pods.