### PR TITLE
mqtt unicast/broadcast support

### DIFF
--- a/lib/python/fledge/backend/local.py
+++ b/lib/python/fledge/backend/local.py
@@ -244,7 +244,7 @@ class LocalBackend(AbstractBackend):
     def loop(self):
         return self._loop
 
-    def add_channel(self, channel):
+    def attach_channel(self, channel):
         self._channels[channel.name()] = channel
 
     def create_tx_task(self, channel_name, end_id):

--- a/lib/python/fledge/channel.py
+++ b/lib/python/fledge/channel.py
@@ -12,11 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Channel."""
 
 import asyncio
 
 import cloudpickle
 
+from .common.constants import CommType
 from .common.util import run_async
 from .config import GROUPBY_DEFAULT_GROUP
 
@@ -25,15 +27,16 @@ TXQ = 'txq'
 
 
 class Channel(object):
-    def __init__(
-        self,
-        backend,
-        job_id: str,
-        name: str,
-        me='',
-        other='',
-        groupby=GROUPBY_DEFAULT_GROUP
-    ):
+    """Channel class."""
+
+    def __init__(self,
+                 backend,
+                 job_id: str,
+                 name: str,
+                 me='',
+                 other='',
+                 groupby=GROUPBY_DEFAULT_GROUP):
+        """Initialize instance."""
         self._backend = backend
         self._job_id = job_id
         self._name = name
@@ -44,43 +47,65 @@ class Channel(object):
         # _ends must be accessed within backend's loop
         self._ends = {}
 
-    def job_id(self):
+        async def _setup_bcast_tx():
+            self._bcast_queue = asyncio.Queue()
+
+            # attach this channel to backend
+            self._backend.attach_channel(self)
+
+            # create tx task for broadcast queue
+            self._backend.create_tx_task(self._name, "", CommType.BROADCAST)
+
+        _, _ = run_async(_setup_bcast_tx(), self._backend.loop())
+
+    def job_id(self) -> str:
+        """Return job id."""
         return self._job_id
 
-    def name(self):
+    def name(self) -> str:
+        """Return channel name."""
         return self._name
 
-    def my_role(self):
+    def my_role(self) -> str:
+        """Return my role's name."""
         return self._my_role
 
-    def other_role(self):
+    def other_role(self) -> str:
+        """Return other role's name."""
         return self._other_role
 
-    def groupby(self):
+    def groupby(self) -> str:
+        """Return groupby tag."""
         return self._groupby
 
-    '''
+    """
     ### The following are not asyncio methods
     ### But access to _ends variable should take place in the backend loop
     ### Therefore, when necessary, coroutine is defined inside each method
     ### and the coroutine is executed via run_async()
-    '''
+    """
 
     def ends(self):
+        """Return a list of ends."""
+
         async def inner():
             return list(self._ends.keys())
 
         result, _ = run_async(inner(), self._backend.loop())
         return result
 
-    def broadcast(self, msg):
-        for end_id in self.ends():
-            self.send(end_id, msg)
+    def broadcast(self, message):
+        """Broadcast a message in a blocking call fashion."""
+
+        async def _put():
+            payload = cloudpickle.dumps(message)
+            await self._bcast_queue.put(payload)
+
+        _, status = run_async(_put(), self._backend.loop())
 
     def send(self, end_id, message):
-        '''
-        send() is a blocking call to send a message to an end
-        '''
+        """Send a message to an end in a blocking call fashion."""
+
         async def _put():
             if not self.has(end_id):
                 # can't send message to end_id
@@ -94,9 +119,8 @@ class Channel(object):
         return status
 
     def recv(self, end_id):
-        '''
-        recv() is a blocking call to receive a message from an end
-        '''
+        """Receive a message from an end in a blocking call fashion."""
+
         async def _get():
             if not self.has(end_id):
                 # can't receive message from end_id
@@ -111,12 +135,17 @@ class Channel(object):
 
         return cloudpickle.loads(payload) if payload and status else None
 
-    '''
+    def join(self):
+        """Join the channel."""
+        self._backend.join(self)
+
+    """
     ### The following are asyncio methods of backend loop
     ### Therefore, they must be called in the backend loop
-    '''
+    """
 
     async def add(self, end_id):
+        """Add an end to the channel and allocate rx and tx queues for it."""
         if self.has(end_id):
             return
 
@@ -126,6 +155,7 @@ class Channel(object):
         self._backend.create_tx_task(self._name, end_id)
 
     async def remove(self, end_id):
+        """Remove an end from the channel."""
         if not self.has(end_id):
             return
 
@@ -136,7 +166,13 @@ class Channel(object):
         await rxq.put(b'')
 
     def has(self, end_id):
+        """Check if an end is in the channel."""
         return end_id in self._ends
 
     def get_q(self, end_id, qtype):
+        """Return a queue of qtype associated wtih an end."""
         return self._ends[end_id][qtype]
+
+    def broadcast_q(self):
+        """Return a broadcast queue object."""
+        return self._bcast_queue

--- a/lib/python/fledge/common/constants.py
+++ b/lib/python/fledge/common/constants.py
@@ -27,3 +27,10 @@ class BackendEvent(Enum):
     """Enum class for BackendEvent."""
 
     DISCONNECT = 1
+
+
+class CommType(Enum):
+    """Enum class for communication type."""
+
+    BROADCAST = 1
+    UNICAST = 2


### PR DESCRIPTION
So far broadcast was supported with mqtt backend. Now both broadcast
and unicast are supported in the backend.

The hack for handling duplicate transmission was also addressed due to
the separation of unicast and broadcast topic.