### PR TITLE
skeleton for enabling fledge plugins

### DIFF
--- a/build/Dockerfile.dev
+++ b/build/Dockerfile.dev
@@ -28,3 +28,5 @@ COPY --from=golang-build /tmp/fledge-job/job-agent.yaml.mustache.minikube /fledg
 # Install fledge python library
 COPY --from=python-build /tmp/*.whl /tmp/
 RUN pip3 install /tmp/*.whl && rm -f /tmp/*.whl
+# this python script configures python packages
+RUN fledge-config

--- a/build/WorkerImagefile
+++ b/build/WorkerImagefile
@@ -10,3 +10,5 @@ COPY --from=base-build /fledge/fledgelet /usr/bin/
 # Install fledge python library
 COPY --from=base-build /tmp/*.whl /tmp/
 RUN pip3 install /tmp/*.whl && rm -f /tmp/*.whl
+# this python script configures python packages
+RUN fledge-config

--- a/lib/python/fledge/analyzer/__init__.py
+++ b/lib/python/fledge/analyzer/__init__.py
@@ -1,0 +1,21 @@
+"""Analyzer abstract class."""
+
+from abc import abstractmethod
+from typing import Any, List, Union
+
+from ..common.typing import Metrics
+from ..plugin import Plugin
+
+
+class AbstractAnalyzer(Plugin):
+    """Abstract base class for analyzer implementation."""
+
+    def callback(self):
+        """Return callback function."""
+        return self.run
+
+    @abstractmethod
+    def run(self,
+            model: Any = None,
+            dataset: Union[None, List[Any]] = None) -> Union[None, Metrics]:
+        """Run analysis and return results."""

--- a/lib/python/fledge/analyzer/dummy.py
+++ b/lib/python/fledge/analyzer/dummy.py
@@ -1,0 +1,30 @@
+"""Analyzer abstract class."""
+
+import logging
+from typing import Any, List, Union
+
+from ..common.typing import Metrics
+from . import AbstractAnalyzer
+
+logger = logging.getLogger(__name__)
+
+
+class DummyAnalyzer(AbstractAnalyzer):
+    """Dummy analyzer.
+
+    Dummy analyzer is only for testing.
+    To enable it create a yaml file (e.g., dummy.yaml) in /etc/fledge/plugin
+    with the following key-valure pairs:
+
+    class: DummyAnalyzer
+    package: fledge.analyzer.dummy
+    type: analyzer
+    """
+
+    def run(self,
+            model: Any = None,
+            dataset: Union[None, List[Any]] = None) -> Union[None, Metrics]:
+        """Run analysis and return results."""
+        logger.info("dummy analyzer: doing nothing")
+
+        return None

--- a/lib/python/fledge/common/typing.py
+++ b/lib/python/fledge/common/typing.py
@@ -1,0 +1,7 @@
+"""Definitions on Types."""
+
+from typing import Any, Dict, Union
+
+Metrics = Dict[str, Union[bool, bytes, float, int, str]]
+
+Dataset = list[Any]

--- a/lib/python/fledge/examples/mnist/aggregator/keras/main.py
+++ b/lib/python/fledge/examples/mnist/aggregator/keras/main.py
@@ -18,6 +18,7 @@ import logging
 from random import randrange
 
 import numpy as np
+from fledge.common.typing import Dataset
 from fledge.config import Config
 from fledge.mode.horizontal.aggregator import Aggregator
 from tensorflow import keras
@@ -35,6 +36,8 @@ class KerasMnistAggregator(Aggregator):
         self.weights = None
         self.metrics = None
         self.model = None
+        # Dataset type is list[Any]
+        self.dataset: Dataset = list()
 
         self.num_classes = 10
         self.input_shape = (28, 28, 1)
@@ -87,6 +90,9 @@ class KerasMnistAggregator(Aggregator):
 
         self._x_test = x_test
         self._y_test = y_test
+
+        # store data into dataset for analysis (e.g., bias)
+        self.dataset = [x_test, y_test]
 
     def train(self) -> None:
         """Train a model."""

--- a/lib/python/fledge/examples/mnist/aggregator/pytorch/main.py
+++ b/lib/python/fledge/examples/mnist/aggregator/pytorch/main.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """MNIST horizontal FL aggregator for PyTorch.
 
 The example below is implemented based on the following example from pytorch:
@@ -24,6 +23,7 @@ import logging
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from fledge.common.typing import Dataset
 from fledge.config import Config
 from fledge.mode.horizontal.aggregator import Aggregator
 from torchvision import datasets, transforms
@@ -70,6 +70,8 @@ class PyTorchMnistAggregator(Aggregator):
         self.weights = None
         self.metrics = None
         self.model = None
+        # Dataset type is list[Any]
+        self.dataset: Dataset = list()
 
         self.device = None
         self.test_loader = None
@@ -98,6 +100,9 @@ class PyTorchMnistAggregator(Aggregator):
                                  transform=transform)
 
         self.test_loader = torch.utils.data.DataLoader(dataset)
+
+        # store data into dataset for analysis (e.g., bias)
+        self.dataset = [self.test_loader.dataset]
 
     def train(self) -> None:
         """Train a model."""

--- a/lib/python/fledge/plugin/__init__.py
+++ b/lib/python/fledge/plugin/__init__.py
@@ -1,0 +1,93 @@
+"""Fledge plugin."""
+
+import importlib
+import logging
+import os
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Tuple, Union
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class PluginType(Enum):
+    """Plugin type enum class."""
+
+    ANALYZER = 1
+
+
+class Plugin(ABC):
+    """Abstract class for plugin."""
+
+    @abstractmethod
+    def callback(self):
+        """Abstract method to return plugin callback function."""
+
+
+class PluginManager(object):
+    """plugin manager class."""
+
+    def __init__(self, plugins_path: str = '/etc/fledge/plugin') -> None:
+        """Initialize instance."""
+        self.filter: set[str] = set()
+        self.plugins: dict[PluginType, list[Plugin]] = dict()
+
+        for filename in os.listdir(plugins_path):
+            filepath = os.path.join(plugins_path, filename)
+            cls_name, package, ptype = self.parse_plugin(filepath)
+            self.register_plugin(cls_name, package, ptype)
+
+    def parse_plugin(self, filepath: str) -> Tuple[str, str, PluginType]:
+        """Parse plugin configuration."""
+        with open(filepath, 'r') as stream:
+            data = yaml.safe_load(stream)
+
+        for key in ['class', 'package', 'type']:
+            if key not in data:
+                raise KeyError(f"{key} not found")
+
+        class_name = data['class']
+        package = data['package']
+        ptype_string = data['type'].upper()
+
+        try:
+            ptype = PluginType[ptype_string]
+        except KeyError:
+            raise KeyError(f"unknown plugin type: {ptype_string}")
+
+        return class_name, package, ptype
+
+    def register_plugin(self, cls_name: str, package: str,
+                        ptype: PluginType) -> None:
+        """Register a plugin."""
+        plugin_key = package + "." + cls_name
+        if plugin_key in self.filter:
+            logger.debug(f"plugin {cls_name} from {package} already loaded")
+            return
+
+        self.filter.add(plugin_key)
+
+        module = importlib.import_module(package)
+
+        try:
+            cls_obj = getattr(module, cls_name)
+        except AttributeError:
+            raise AttributeError(f'class {cls_name} not found')
+
+        plugin_instance = cls_obj()
+        if not isinstance(plugin_instance, Plugin):
+            raise TypeError("not a plugin")
+
+        # TODO: implement security check
+        #       e.g., only allow  registration of whitelisted plugins
+
+        if ptype not in self.plugins:
+            self.plugins[ptype] = []
+
+        self.plugins[ptype].append(plugin_instance)
+
+    def get_plugins(self, ptype: PluginType) -> Union[None, list[Plugin]]:
+        """Return a list of plugins of a given plugin type."""
+        return self.plugins[ptype] if ptype in self.plugins else None

--- a/lib/python/scripts/fledge-config
+++ b/lib/python/scripts/fledge-config
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+
+import os
+
+if __name__ == '__main__':
+    os.makedirs('/etc/fledge/plugin', 0o755)

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -18,7 +18,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='fledge',
-    version='0.0.6',
+    version='0.0.7',
     author='Myungjin Lee',
     author_email='myungjle@cisco.com',
     include_package_data=True,
@@ -42,7 +42,7 @@ setup(
                  ['fledge/examples/simple/bar/config.json']),
                 ('fledge/examples/simple/foo',
                  ['fledge/examples/simple/foo/config.json'])],
-    scripts=[],
+    scripts=['scripts/fledge-config'],
     url='https://github.com/cisco/fledge/',
     license='LICENSE.txt',
     description="This package is a python library"


### PR DESCRIPTION
To order to allow functionality extension, a plugin manager is
implemented. As a basic validation, dummy analyzer (a simple plugin
in the analyzer plugin type) is implemented.

A package built by inheriting Plugin class (an abstract class) can be
loaded into fledge python process at start time when its spec is
described in /etc/fledge/plugin as a yaml file.

An example for the dummy analyzer is:
class: DummyAnalyzer # the name of class built by inheriting Plugin
package: fledge.analyzer.dummy # module path
type: analyzer

Currently, only analyzer plugin type is supported.