### PR TITLE
fix: one selector per channel

### DIFF
--- a/lib/python/flame/examples/hier_mnist/middle_aggregator/config_uk.json
+++ b/lib/python/flame/examples/hier_mnist/middle_aggregator/config_uk.json
@@ -66,8 +66,8 @@
 	"uri": "http://mlflow:5000"
     },
     "selector": {
-	"sort": "default",
-	"kwargs": {}
+	"sort": "random",
+	"kwargs": {"k": 1}
     },
     "maxRunTime": 300,
     "realm": "uk/london/org2/flame",

--- a/lib/python/flame/examples/hier_mnist/trainer/config_uk.json
+++ b/lib/python/flame/examples/hier_mnist/trainer/config_uk.json
@@ -50,8 +50,8 @@
 	"uri": "http://mlflow:5000"
     },
     "selector": {
-	"sort": "default",
-	"kwargs": {}
+	"sort": "random",
+	"kwargs": {"k": 1}
     },
     "maxRunTime": 300,
     "realm": "uk/london/org2/machine1",


### PR DESCRIPTION
Previously, only one selector is initialized and then used across many channels. Now it's changed to one selector per channel. Also, the middle aggregator now has the round counter too in order to trigger the random selector. With this fix, the hierarchical FL is tested properly with a 7-pod simulation (i.e., 1 top aggregator, 2 middle aggregators, and 4 trainers).

type | file | changes
-- | -- | --
modified | lib/python/flame/channel_manager.py | changed selector initialization mechanism
modified | lib/python/flame/mode/horizontal/middle_aggregator.py | added a function to increment round so that the selector is able to re-select
modified | lib/python/flame/examples/hier_mnist/middle_aggregator/config_uk.json | config for testing
modified | lib/python/flame/examples/hier_mnist/trainer/config_uk.json | config for testing

