### PR TITLE
refactor: simplify middle aggregator

### DIFF
--- a/lib/python/flame/examples/hier_mnist/middle_aggregator/main.py
+++ b/lib/python/flame/examples/hier_mnist/middle_aggregator/main.py
@@ -16,14 +16,10 @@
 """HIRE_MNIST horizontal hierarchical FL middle level aggregator for Keras."""
 
 import logging
-from random import randrange
 
-import numpy as np
 from flame.config import Config
-from flame.dataset import Dataset
 from flame.mode.horizontal.middle_aggregator import MiddleAggregator
 from tensorflow import keras
-from tensorflow.keras import layers
 
 logger = logging.getLogger(__name__)
 
@@ -34,68 +30,15 @@ class KerasMnistMiddleAggregator(MiddleAggregator):
         """Initialize a class instance."""
         self.config = config
         self.weights = None
-        self.metrics = None
-        self.model = None
         self.dataset_size = 0
-
-        self.dataset: Dataset = None
-
-        self.num_classes = 10
-        self.input_shape = (28, 28, 1)
-
-        self._x_test = None
-        self._y_test = None
 
     def initialize(self):
         """Initialize role."""
-        if not self.model:
-            model = keras.Sequential([
-                keras.Input(shape=self.input_shape),
-                layers.Conv2D(32, kernel_size=(3, 3), activation="relu"),
-                layers.MaxPooling2D(pool_size=(2, 2)),
-                layers.Conv2D(64, kernel_size=(3, 3), activation="relu"),
-                layers.MaxPooling2D(pool_size=(2, 2)),
-                layers.Flatten(),
-                layers.Dropout(0.5),
-                layers.Dense(self.num_classes, activation="softmax"),
-            ])
-
-            model.compile(loss="categorical_crossentropy",
-                          optimizer="adam",
-                          metrics=["accuracy"])
-
-            self.model = model
-
-        # initialize the global model weights
-        self.weights = self.model.get_weights()
+        pass
 
     def load_data(self) -> None:
         """Load a test dataset."""
-        if self.dataset:
-            return
-
-        # the data, split between train and test sets
-        (_, _), (x_test, y_test) = keras.datasets.mnist.load_data()
-
-        split_n = 5
-        index = randrange(split_n)
-        # reduce test sample size to reduce the runtime
-        x_test = np.split(x_test, split_n)[index]
-        y_test = np.split(y_test, split_n)[index]
-
-        # Scale images to the [0, 1] range
-        x_test = x_test.astype("float32") / 255
-        # Make sure images have shape (28, 28, 1)
-        x_test = np.expand_dims(x_test, -1)
-
-        # convert class vectors to binary class matrices
-        y_test = keras.utils.to_categorical(y_test, self.num_classes)
-
-        self._x_test = x_test
-        self._y_test = y_test
-
-        # store data into dataset for analysis (e.g., bias)
-        self.dataset = Dataset(x=x_test, y=y_test)
+        pass
 
     def train(self) -> None:
         """Train a model."""
@@ -104,17 +47,7 @@ class KerasMnistMiddleAggregator(MiddleAggregator):
 
     def evaluate(self) -> None:
         """Evaluate (test) a model."""
-        # set updated model weights
-        self.model.set_weights(self.weights)
-
-        score = self.model.evaluate(self._x_test, self._y_test, verbose=0)
-
-        logger.info(f"Test loss: {score[0]}")
-        logger.info(f"Test accuracy: {score[1]}")
-
-        # set metrics after each evaluation so that the metrics can be logged
-        # in a model registry.
-        self.metrics = {'loss': score[0], 'accuracy': score[1]}
+        pass
 
 if __name__ == "__main__":
     import argparse


### PR DESCRIPTION
Remove evaluation from the middle aggregator, so that the middle aggregator acts merely as a tool of communication and aggregation.

type | file | changes
-- | -- | --
modified | lib/python/flame/examples/hier_mnist/middle_aggregator/main.py | removed data-and-model-related code
modified | lib/python/flame/mode/horizontal/middle_aggregator.py | removed unused abstract attributes/functions.