### PR TITLE
chore: clean up unneeded file

### DIFF
--- a/examples/fledgectl/config.yaml
+++ b/examples/fledgectl/config.yaml
@@ -1,5 +1,0 @@
-# configuration for local fiab environment
-# place it in $HOME/.flame folder
-apiserver:
-  endpoint: 127.0.0.1:10100
-user: john


### PR DESCRIPTION
The config.yaml is incorrect under minikube environment.
fiab env provides a script to generate this file correctly.
So, this file is deleted.