### PR TITLE
update grpc insecure option

### DIFF
--- a/cmd/controller/app/job/notify.go
+++ b/cmd/controller/app/job/notify.go
@@ -21,6 +21,7 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	pbNotify "github.com/cisco-open/flame/pkg/proto/notification"
 )
@@ -37,7 +38,7 @@ func newNotifyClient(endpoint string) *notifyClient {
 
 // sendNotification sends a notification request to the notifier
 func (nc *notifyClient) sendNotification(req *pbNotify.EventRequest) (*pbNotify.Response, error) {
-	conn, err := grpc.Dial(nc.endpoint, grpc.WithInsecure())
+	conn, err := grpc.Dial(nc.endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to notifier: %v", err)
 	}

--- a/cmd/flamelet/app/taskhandler.go
+++ b/cmd/flamelet/app/taskhandler.go
@@ -29,6 +29,7 @@ import (
 	backoff "github.com/cenkalti/backoff/v4"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/cisco-open/flame/pkg/openapi"
 	pbNotify "github.com/cisco-open/flame/pkg/proto/notification"
@@ -102,7 +103,7 @@ func (t *taskHandler) doStart() {
 
 func (t *taskHandler) connect() error {
 	// dial server
-	conn, err := grpc.Dial(t.notifierEp, grpc.WithInsecure())
+	conn, err := grpc.Dial(t.notifierEp, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		zap.S().Debugf("Cannot connect with notifier: %v", err)
 		return err


### PR DESCRIPTION
grpc.WithInsecure is deprecated. The option is replaced with
WithTransportCredentials and insecure.NewCredentials().