### PR TITLE
fix: correct flame script

### DIFF
--- a/fiab/flame.sh
+++ b/fiab/flame.sh
@@ -19,7 +19,7 @@
 RELEASE_NAME=flame
 
 FILE_OF_INTEREST=helm-chart/values.yaml
-LINES_OF_INTEREST="22,29"
+LINES_OF_INTEREST="38,45"
 
 function init {
     cd helm-chart


### PR DESCRIPTION
Corrected the line numbers discrepancy caused by the addition of a license.

type | file | changes
-- | -- | --
modified | fiab/flame.sh | changed line numbers