### PR TITLE
Bump golang docker image to 1.17.8-buster

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.16.4-buster AS golang-build
+FROM golang:1.17.8-buster AS golang-build
 WORKDIR /src
 ENV CGO_ENABLED=0
 RUN --mount=target=. \


### PR DESCRIPTION
Due to package update to resolve security issues, some packages now
require golang 1.17. Hence, golang docker image version is bumped.