### PR TITLE
fix: fedavg algo

### DIFF
--- a/lib/python/flame/optimizer/fedavg.py
+++ b/lib/python/flame/optimizer/fedavg.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-
 """Federated Averaging optimizer."""
 import logging
 
@@ -49,6 +48,9 @@ class FedAvg(AbstractOptimizer):
         Return: aggregated model
         """
         logger.debug("calling fedavg")
+
+        # reset global weights before aggregation
+        self.agg_weights = None
 
         if len(cache) == 0 or total == 0:
             return None


### PR DESCRIPTION
The previous global weights were not reset before new global weights
are computed in each round. This caused loss value increase over
rounds. This error is fixed.