### PR TITLE
make job agent config flexible

### DIFF
--- a/templates/job/job-agent.yaml.mustache
+++ b/templates/job/job-agent.yaml.mustache
@@ -15,9 +15,9 @@ spec:
       containers:
         - args:
             - "--apiserver"
-            - "http://{{ .Values.servicename }}-apiserver:{{ .Values.componentPorts.apiserver }}"
+            - "{{ .Values.endpoints.apiserver }}"
             - "--notifier"
-            - "{{ .Values.servicename }}-notifier:{{ .Values.componentPorts.notifier }}"
+            - "{{ .Values.endpoints.notifier }}"
           command: ["/usr/bin/flamelet"]
           image: <% imageLoc %>
           imagePullPolicy: IfNotPresent

--- a/templates/job/values.yaml
+++ b/templates/job/values.yaml
@@ -19,3 +19,7 @@ componentPorts:
   apiserver: "10100"
   notifier: "10101"
   agent: "10103"
+
+endpoints:
+  apiserver: http://flame-apiserver:10100
+  notifier: flame-notifier:10101


### PR DESCRIPTION
The parameters for apiserver and notifier are not flexible as some
parts in the endpoints are hard-coded. Now users can update
values.yaml to set endpoints as they want.