### PR TITLE
feature: distributed training with mqtt

### DIFF
--- a/lib/python/flame/config.py
+++ b/lib/python/flame/config.py
@@ -66,7 +66,7 @@ GROUPBY_DEFAULT_GROUP = 'default'
 DEFAULT_HYPERARAMETERS_DICT = {
     'rounds': 1,
     'epochs': 1,
-    'batchSize': 16,
+    'batchSize': 16
 }
 
 

--- a/lib/python/flame/examples/dist_mnist/__init__.py
+++ b/lib/python/flame/examples/dist_mnist/__init__.py
@@ -14,15 +14,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
-"""Message class."""
-
-from enum import Enum
-
-class MessageType(Enum):
-    """Define Message types."""
-
-    WEIGHTS = 1  # model weights
-    EOT = 2  # end of training
-    DATASET_SIZE = 3 # dataset size
-    ROUND = 4 # round number

--- a/lib/python/flame/examples/dist_mnist/trainer/__init__.py
+++ b/lib/python/flame/examples/dist_mnist/trainer/__init__.py
@@ -14,15 +14,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
-"""Message class."""
-
-from enum import Enum
-
-class MessageType(Enum):
-    """Define Message types."""
-
-    WEIGHTS = 1  # model weights
-    EOT = 2  # end of training
-    DATASET_SIZE = 3 # dataset size
-    ROUND = 4 # round number

--- a/lib/python/flame/examples/dist_mnist/trainer/config.json
+++ b/lib/python/flame/examples/dist_mnist/trainer/config.json
@@ -1,0 +1,61 @@
+{
+    "taskid": "505f9fc483cf4df68a2409257b5fad7d3c580370",
+    "backend": "mqtt",
+    "brokers": [
+        {
+            "host": "mosquitto",
+            "sort": "mqtt"
+        }
+    ],
+    "channels": [
+        {
+            "description": "Model update is sent from a trainer to another trainer",
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default/us"
+                ]
+            },
+            "name": "param-channel",
+            "pair": [
+                "trainer",
+                "trainer"
+            ],
+	    "funcTags": {
+                "trainer": ["fetch", "upload"]
+            }
+        }
+    ],
+    "dataset": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz",
+    "dependencies": [
+        "numpy >= 1.2.0"
+    ],
+    "hyperparameters": {
+        "batchSize": 32,
+        "learningRate": 0.01,
+        "rounds": 10
+    },
+    "baseModel": {
+	    "name": "",
+	    "version": 1
+    },
+    "job" : {
+	    "id": "622a358619ab59012eabeefb",
+	    "name": "dist_mnist"
+    },
+    "registry": {
+	    "sort": "mlflow",
+	    "uri": "http://mlflow:5000"
+    },
+    "selector": {
+	    "sort": "default",
+	    "kwargs": {}
+    },
+    "optimizer": {
+        "sort": "fedavg",
+        "kwargs": {}
+    },
+    "maxRunTime": 300,
+    "realm": "default/us",
+    "role": "trainer"
+}

--- a/lib/python/flame/examples/dist_mnist/trainer/main.py
+++ b/lib/python/flame/examples/dist_mnist/trainer/main.py
@@ -1,0 +1,141 @@
+# Copyright 2022 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""MNIST distributed learning trainer for Keras."""
+
+import logging
+from random import randrange
+from statistics import mean
+
+import numpy as np
+from flame.config import Config
+from flame.mode.distributed.trainer import Trainer
+from tensorflow import keras
+from tensorflow.keras import layers
+
+logger = logging.getLogger(__name__)
+
+
+class KerasMnistTrainer(Trainer):
+    """Keras Mnist Trainer."""
+
+    def __init__(self, config: Config) -> None:
+        """Initialize a class instance."""
+        self.config = config
+        self.dataset_size = 0
+
+        self.num_classes = 10
+        self.input_shape = (28, 28, 1)
+
+        self.model = None
+        self._x_train = None
+        self._y_train = None
+        self._x_test = None
+        self._y_test = None
+
+        self.epochs = self.config.hyperparameters['epochs']
+        self.batch_size = 128
+        if 'batchSize' in self.config.hyperparameters:
+            self.batch_size = self.config.hyperparameters['batchSize']
+
+    def initialize(self) -> None:
+        """Initialize role."""
+        model = keras.Sequential([
+            keras.Input(shape=self.input_shape),
+            layers.Conv2D(32, kernel_size=(3, 3), activation="relu"),
+            layers.MaxPooling2D(pool_size=(2, 2)),
+            layers.Conv2D(64, kernel_size=(3, 3), activation="relu"),
+            layers.MaxPooling2D(pool_size=(2, 2)),
+            layers.Flatten(),
+            layers.Dropout(0.5),
+            layers.Dense(self.num_classes, activation="softmax"),
+        ])
+
+        model.compile(loss="categorical_crossentropy",
+                      optimizer="adam",
+                      metrics=["accuracy"])
+
+        self.model = model
+
+    def load_data(self) -> None:
+        """Load data."""
+        # the data, split between train and test sets
+        (x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+
+        split_n = 10
+        index = randrange(split_n)
+        # reduce train sample size to reduce the runtime
+        x_train = np.split(x_train, split_n)[index]
+        y_train = np.split(y_train, split_n)[index]
+        x_test = np.split(x_test, split_n)[index]
+        y_test = np.split(y_test, split_n)[index]
+
+        # Scale images to the [0, 1] range
+        x_train = x_train.astype("float32") / 255
+        x_test = x_test.astype("float32") / 255
+        # Make sure images have shape (28, 28, 1)
+        x_train = np.expand_dims(x_train, -1)
+        x_test = np.expand_dims(x_test, -1)
+
+        # convert class vectors to binary class matrices
+        y_train = keras.utils.to_categorical(y_train, self.num_classes)
+        y_test = keras.utils.to_categorical(y_test, self.num_classes)
+
+        self._x_train = x_train
+        self._y_train = y_train
+        self._x_test = x_test
+        self._y_test = y_test
+
+    def train(self) -> None:
+        """Train a model."""
+        history = self.model.fit(self._x_train,
+                                 self._y_train,
+                                 batch_size=self.batch_size,
+                                 epochs=self.epochs,
+                                 validation_split=0.1)
+
+        # save dataset size so that the info can be shared with aggregator
+        self.dataset_size = len(self._x_train)
+
+        loss = mean(history.history['loss'])
+        accuracy = mean(history.history['accuracy'])
+        self.update_metrics({'loss': loss, 'accuracy': accuracy})
+
+    def evaluate(self) -> None:
+        """Evaluate a model."""
+        score = self.model.evaluate(self._x_test, self._y_test, verbose=0)
+
+        logger.info(f"Test loss: {score[0]}")
+        logger.info(f"Test accuracy: {score[1]}")
+
+        # update metrics after each evaluation so that the metrics can be
+        # logged in a model registry.
+        self.update_metrics({'test-loss': score[0], 'test-accuracy': score[1]})
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('config', nargs='?', default="./config.json")
+
+    args = parser.parse_args()
+
+    config = Config(args.config)
+
+    t = KerasMnistTrainer(config)
+    t.compose()
+    t.run()

--- a/lib/python/flame/mode/distributed/__init__.py
+++ b/lib/python/flame/mode/distributed/__init__.py
@@ -14,15 +14,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
-"""Message class."""
-
-from enum import Enum
-
-class MessageType(Enum):
-    """Define Message types."""
-
-    WEIGHTS = 1  # model weights
-    EOT = 2  # end of training
-    DATASET_SIZE = 3 # dataset size
-    ROUND = 4 # round number

--- a/lib/python/flame/mode/distributed/trainer.py
+++ b/lib/python/flame/mode/distributed/trainer.py
@@ -1,0 +1,241 @@
+# Copyright 2022 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""distributed FL trainer."""
+
+import logging
+import time
+
+from diskcache import Cache
+
+from ...channel_manager import ChannelManager
+from ...common.custom_abcmeta import ABCMeta, abstract_attribute
+from ...common.util import (MLFramework, get_ml_framework_in_use,
+                            valid_frameworks,  mlflow_runname)
+from ...optimizer.train_result import TrainResult
+from ...optimizers import optimizer_provider
+from ...registries import registry_provider
+from ..composer import Composer
+from ..role import Role
+from ..message import MessageType
+from ..tasklet import Loop, Tasklet
+
+logger = logging.getLogger(__name__)
+
+TAG_FETCH = 'fetch'
+TAG_UPLOAD = 'upload'
+
+
+class Trainer(Role, metaclass=ABCMeta):
+    """Trainer implements an ML training role."""
+
+    @abstract_attribute
+    def config(self):
+        """Abstract attribute for config object."""
+
+    @abstract_attribute
+    def dataset_size(self):
+        """Abstract attribute for size of dataset used to train."""
+
+    def internal_init(self) -> None:
+        """Initialize internal state for role."""
+        self.cm = ChannelManager()
+        self.cm(self.config)
+        self.cm.join_all()
+
+        self.registry_client = registry_provider.get(self.config.registry.sort)
+        # initialize registry client
+        self.registry_client(self.config.registry.uri, self.config.job.job_id)
+
+        base_model = self.config.base_model
+        if base_model and base_model.name != "" and base_model.version > 0:
+            self.model = self.registry_client.load_model(
+                base_model.name, base_model.version)
+
+        self.registry_client.setup_run(mlflow_runname(self.config))
+        self.metrics = dict()
+
+        self.cache = Cache()
+        self.total_data_points = 0
+        self.optimizer = optimizer_provider.get(self.config.optimizer.sort,
+                                                **self.config.optimizer.kwargs)
+
+        self._round = 1
+        self._rounds = self.config.hyperparameters['rounds']
+        self._work_done = False
+
+        self.framework = get_ml_framework_in_use()
+        if self.framework == MLFramework.UNKNOWN:
+            raise NotImplementedError(
+                "supported ml framework not found; "
+                f"supported frameworks are: {valid_frameworks}")
+
+    def get(self, tag: str) -> None:
+        """Get data from remote role(s)."""
+        if tag == TAG_FETCH:
+            self._fetch_weights(tag)
+
+    def _fetch_weights(self, tag: str) -> None:
+        logger.debug("calling _fetch_weights")
+        channel = self.cm.get_by_tag(tag)
+        if not channel:
+            logger.debug(f"[_fetch_weights] channel not found with tag {tag}")
+            return
+
+        while channel.empty():
+            logger.debug("[_fetch_weights] waiting for channel ends")
+            time.sleep(1)
+
+        self.total_data_points = 0
+        for end in channel.ends():
+            dict = channel.recv(end)
+            if not dict:
+                logger.debug(f"No data received from {end}")
+                continue
+
+            for k, v in dict.items():
+                if k == MessageType.WEIGHTS:
+                    weights = v
+                elif k == MessageType.DATASET_SIZE:
+                    count = v
+                elif k == MessageType.ROUND and v > self._round:
+                    self._round = v
+
+            self.total_data_points += count
+            logger.debug(f"{end}'s parameters trained with {count} samples")
+
+            if weights is not None:
+                tres = TrainResult(weights, count)
+                self.cache[end] = tres
+
+    def _aggregate_weights(self) -> None:
+        logger.debug("aggregating weights from all trainers")
+        global_weights = self.optimizer.do(self.cache, self.total_data_points)
+        if global_weights is None:
+            logger.debug("failed model aggregation")
+            return
+ 
+        # set global weights
+        self.weights = global_weights
+        # update model with global weights
+        self._update_model()
+
+    def put(self, tag: str) -> None:
+        """Set data to remote role(s)."""
+        if tag == TAG_UPLOAD:
+            self._send_weights(tag)
+
+    def _send_weights(self, tag: str) -> None:
+        logger.debug("calling _send_weights")
+        channel = self.cm.get_by_tag(tag)
+        if not channel:
+            logger.debug(f"[_send_weights] channel not found with {tag}")
+            return
+
+        while channel.empty():
+            logger.debug("[_send_weights] waiting for channel ends")
+            time.sleep(1)
+
+        self._update_weights()
+        channel.broadcast({MessageType.WEIGHTS: self.weights if self._round != 1 else None, 
+                           MessageType.DATASET_SIZE: self.dataset_size, 
+                           MessageType.ROUND: self._round})
+        logger.debug("broadcasting weights done")
+
+    def save_metrics(self):
+        """Save metrics in a model registry."""
+        logger.debug(f"saving metrics: {self.metrics}")
+        if self.metrics:
+            self.registry_client.save_metrics(self._round, self.metrics)
+            logger.debug("saving metrics done")
+
+    def update_metrics(self, metrics: dict[str, float]):
+        """Update metrics."""
+        self.metrics = self.metrics | metrics
+
+    def _update_model(self):
+        if self.framework == MLFramework.PYTORCH:
+            self.model.load_state_dict(self.weights)
+        elif self.framework == MLFramework.TENSORFLOW:
+            self.model.set_weights(self.weights)
+
+    def _update_weights(self):
+        if self.framework == MLFramework.PYTORCH:
+            self.weights = self.model.state_dict()
+        elif self.framework == MLFramework.TENSORFLOW:
+            self.weights = self.model.get_weights()
+
+    def increment_round(self):
+        """Increment the round counter."""
+        logger.debug(f"Incrementing current round: {self._round}")
+        self._round += 1
+        self._work_done = (self._round > self._rounds)
+
+    def save_params(self):
+        """Save hyperparamets in a model registry."""
+        if self.config.hyperparameters:
+            self.registry_client.save_params(self.config.hyperparameters)
+
+    def save_model(self):
+        """Save model in a model registry."""
+        if self.model:
+            model_name = f"{self.config.job.name}-{self.config.job.job_id}"
+            self.registry_client.save_model(model_name, self.model)
+
+    def compose(self) -> None:
+        """Compose role with tasklets."""
+        with Composer() as composer:
+            self.composer = composer
+
+            task_internal_init = Tasklet(self.internal_init)
+
+            task_load_data = Tasklet(self.load_data)
+
+            task_init = Tasklet(self.initialize)
+
+            task_get = Tasklet(self.get, TAG_FETCH)
+
+            task_train = Tasklet(self.train)
+
+            task_eval = Tasklet(self.evaluate)
+
+            task_put = Tasklet(self.put, TAG_UPLOAD)
+
+            task_aggregate = Tasklet(self._aggregate_weights)
+
+            task_increment_round = Tasklet(self.increment_round)
+
+            task_save_metrics = Tasklet(self.save_metrics)
+
+            task_save_params = Tasklet(self.save_params)
+
+            task_save_model = Tasklet(self.save_model)
+
+            # create a loop object with loop exit condition function
+            loop = Loop(loop_check_fn=lambda: self._work_done)
+            task_internal_init >> task_load_data >> task_init >> loop(
+                task_put >> task_get >> task_aggregate 
+                >> task_train >> task_eval >> task_save_metrics 
+                >> task_increment_round) >> task_save_params >> task_save_model
+
+    def run(self) -> None:
+        """Run role."""
+        self.composer.run()
+
+    @classmethod
+    def get_func_tags(cls) -> list[str]:
+        """Return a list of function tags defined in the trainer role."""
+        return [TAG_FETCH, TAG_UPLOAD]


### PR DESCRIPTION
This is an example of distributed training with the MQTT backend. It's for demonstration purposes so It doesn't have efficient communication backends for now. This distributed training mode will work even if there is only one trainer. The newly-joined trainer will receive the latest aggregated weights before start contributing.

type | file | changes
-- | -- | --
modified | lib/python/flame/config.py | add the number of distributed learning nodes to the configuration
modified | lib/python/flame/mode/message.py | add new message types
created | lib/python/flame/examples/dist_mnist/\__init__.py | 
created | lib/python/flame/examples/dist_mnist/trainer/\__init__.py | 
created | lib/python/flame/examples/dist_mnist/trainer/config.json | example config
created | lib/python/flame/examples/dist_mnist/trainer/main.py | borrowed from MNIST example
created | lib/python/flame/mode/distributed/\__init__.py | 
created | lib/python/flame/mode/distributed/trainer.py | created a new trainer class to handle distributed mode