### PR TITLE
fix: deadlock case in default selector

### DIFF
--- a/lib/python/flame/mode/horizontal/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/top_aggregator.py
@@ -23,7 +23,7 @@ from diskcache import Cache
 from ...channel_manager import ChannelManager
 from ...common.custom_abcmeta import ABCMeta, abstract_attribute
 from ...common.util import (MLFramework, get_ml_framework_in_use,
-                            valid_frameworks, mlflow_runname)
+                            mlflow_runname, valid_frameworks)
 from ...optimizer.train_result import TrainResult
 from ...optimizers import optimizer_provider
 from ...plugin import PluginManager, PluginType
@@ -109,6 +109,7 @@ class TopAggregator(Role, metaclass=ABCMeta):
         total = 0
         # receive local model parameters from trainers
         for end in channel.ends():
+            logger.debug(f"waiting to receive data from {end}")
             msg = channel.recv(end)
             if not msg:
                 logger.debug(f"No data received from {end}")

--- a/lib/python/flame/selector/default.py
+++ b/lib/python/flame/selector/default.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-
 """DefaultSelector class."""
 
 import logging
@@ -28,10 +27,23 @@ logger = logging.getLogger(__name__)
 class DefaultSelector(AbstractSelector):
     """A default selector class."""
 
+    def __init__(self):
+        """Initailize instance."""
+        super().__init__()
+        self.round = 0
+
     def select(self, ends: dict[str, End],
                channel_props: dict[str, Scalar]) -> SelectorReturnType:
         """Return all ends from the given ends."""
         logger.debug("calling default select")
 
-        self.selected_ends = ends.keys()
+        round = channel_props['round'] if 'round' in channel_props else 0
+
+        if len(self.selected_ends) == 0 or round > self.round:
+            logger.debug(f"let's select the whole ends for new round {round}")
+            self.selected_ends = list(ends.keys())
+            self.round = round
+
+        logger.debug(f"selected ends: {self.selected_ends}")
+
         return {key: None for key in self.selected_ends}


### PR DESCRIPTION
A deadlock occurs when workers join late after aggregator distributes
global parameters. This is because the aggregator will wait for local
parameters from those workers to which it didn't distribute the global
parameters. To solve the issue, the default selector remembers a set
of workers it distributed the global parameters in each round and
within the round the aggregator will try to receive local parameters
from the same set of workers.