### PR TITLE
feature: dummy model registry client

### DIFF
--- a/lib/python/flame/config.py
+++ b/lib/python/flame/config.py
@@ -79,7 +79,8 @@ class BackendType(Enum):
 class RegistryType(Enum):
     """Define model registry types."""
 
-    MLFLOW = 1
+    DUMMY = 1
+    MLFLOW = 2
 
 
 class OptimizerType(Enum):
@@ -338,7 +339,7 @@ class Config(object):
                 except:
                     valid_types = [backend.name for backend in BackendType]
                     sys.exit(f"invailid backend type: {backend_key}\n" +
-                    f"valid backend type(s) are {valid_types}")
+                             f"valid backend type(s) are {valid_types}")
                 self.channel_brokers[k] = Config.Brokers(v['brokers'])
 
     def __init__(self, config_file: str):

--- a/lib/python/flame/registries.py
+++ b/lib/python/flame/registries.py
@@ -13,23 +13,25 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-
 """Model registry provider."""
 
 from typing import Union
 
 from .config import RegistryType
 from .object_factory import ObjectFactory
+from .registry.dummy import DummyRegistryClient
 from .registry.mlflow import MLflowRegistryClient
 
 
 class RegistryProvider(ObjectFactory):
     """Model registry provider."""
 
-    def get(self, registry_name, **kwargs) -> Union[MLflowRegistryClient]:
+    def get(self, registry_name,
+            **kwargs) -> Union[DummyRegistryClient, MLflowRegistryClient]:
         """Return a registry client for a given registry name."""
         return self.create(registry_name, **kwargs)
 
 
 registry_provider = RegistryProvider()
+registry_provider.register(RegistryType.DUMMY, DummyRegistryClient)
 registry_provider.register(RegistryType.MLFLOW, MLflowRegistryClient)

--- a/lib/python/flame/registry/dummy.py
+++ b/lib/python/flame/registry/dummy.py
@@ -13,40 +13,41 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-"""Abstract registry client."""
+"""Dummmy registry client."""
 
-from abc import ABC, abstractmethod
 from typing import Any, Optional
 
+from .abstract import AbstractRegistryClient
 
-class AbstractRegistryClient(ABC):
-    """Abstract registry client."""
 
-    @abstractmethod
+class DummyRegistryClient(AbstractRegistryClient):
+    """Dummy registry client."""
+
     def __call__(self, uri: str, job_id: str) -> None:
-        """Abstract method for initializing a registry client."""
+        """Initialize the instance."""
+        pass
 
-    @abstractmethod
     def setup_run(self, name: str) -> None:
-        """Abstract method for setup a run."""
+        """Set up a run."""
+        pass
 
-    @abstractmethod
     def save_metrics(self, epoch: int, metrics: Optional[dict[str,
                                                               float]]) -> None:
-        """Abstract method for saving metrics in a model registry."""
+        """Save metrics in a model registry."""
+        pass
 
-    @abstractmethod
     def save_params(self, hyperparameters: Optional[dict[str, float]]) -> None:
-        """Abstract method for saving hyperparameters in a model registry."""
+        """Save hyperparameters in a model registry."""
+        pass
 
-    @abstractmethod
     def cleanup(self) -> None:
-        """Abstract method for cleanning up resources."""
+        """Clean up resources."""
+        pass
 
-    @abstractmethod
     def save_model(self, name: str, model: Any) -> None:
-        """Abstract method for saving a model in a model registry."""
+        """Save a model in a model registry."""
+        pass
 
-    @abstractmethod
     def load_model(self, name: str, version: int) -> object:
-        """Abstract method for loading a model from a model registry."""
+        """Load a model from a model registry."""
+        pass

--- a/lib/python/flame/registry/mlflow.py
+++ b/lib/python/flame/registry/mlflow.py
@@ -63,7 +63,7 @@ class MLflowRegistryClient(AbstractRegistryClient):
 
         self.experiment = experiment
 
-    def setup_run(self, name: str):
+    def setup_run(self, name: str) -> None:
         """
         Set up a run for logging parameters, metrics and model.
 


### PR DESCRIPTION
A dummy model registry client is implemented. This allows an
experiment without having a proper model registry such as mlflow.