### PR TITLE
feature: log artifact to mlflow

### DIFF
--- a/lib/python/flame/registry/mlflow.py
+++ b/lib/python/flame/registry/mlflow.py
@@ -90,6 +90,10 @@ class MLflowRegistryClient(AbstractRegistryClient):
             return
 
         mlflow.log_params(hyperparameters)
+    
+    def save_artifact(self, local_path: str) -> None:
+        """Save an artifact in a model registry."""
+        mlflow.log_artifact(local_path) # path could be a path to a file or a directory
 
     def cleanup(self) -> None:
         """


### PR DESCRIPTION
This is a simple yet effective feature from mlflow that allows user to add artifact of any types of data such as png, csv, pickle, etc. Recommend to be included in the next release.

type | file | changes
-- | -- | --
modified | lib/python/flame/registry/mlflow.py | add api for logging artifacts to MLFLow
