### PR TITLE
[control-plane] First commit for deployer as separate pod

### DIFF
--- a/cmd/deployer/app/appserver.go
+++ b/cmd/deployer/app/appserver.go
@@ -1,0 +1,1 @@
+package app

--- a/cmd/deployer/app/service.go
+++ b/cmd/deployer/app/service.go
@@ -1,0 +1,1 @@
+package app

--- a/cmd/deployer/cmd/root.go
+++ b/cmd/deployer/cmd/root.go
@@ -1,0 +1,1 @@
+package cmd

--- a/cmd/deployer/main.go
+++ b/cmd/deployer/main.go
@@ -1,0 +1,14 @@
+package main
+
+import "time"
+
+func main() {
+	go forever()
+	select {} // block forever
+}
+
+func forever() {
+	for {
+		time.Sleep(time.Second)
+	}
+}

--- a/fiab/helm-chart/templates/deployer-deployment.yaml
+++ b/fiab/helm-chart/templates/deployer-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-deployer
+  namespace: {{ .Release.Namespace }}
+
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-deployer
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-deployer
+    spec:
+      containers:
+        - args: []
+          command: ["/usr/bin/deployer"]
+          image: {{ .Values.imageName }}:{{ .Values.imageTag }}
+          imagePullPolicy: IfNotPresent
+          name: {{ .Release.Name }}-deployer

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -66,6 +66,7 @@ const (
 	ApiServer  = "apiserver"
 	Controller = "controller"
 	Notifier   = "notifier"
+	Deployer   = "deployer"
 	CliTool    = "flamectl"
 
 	// file permission


### PR DESCRIPTION
This initiates an important change for the flame controlplane. We will be developing a separate `deployer` service to de-couple the current `deployer` from `controller`. A separate `deployer` service required to add support for Flame to run across multiple clusters.

This first commit creates a separate `pod` for deployer that is perpetually in a `running` state. To enable this, a placeholder app for the deployer was created and the helm-chart files were also added. The app will be implemented in the future commits to expose all the required services for the deployer.
<img width="610" alt="Deployer_pod" src="https://user-images.githubusercontent.com/22317973/173980567-932cb5f2-111d-4c92-be44-4600ae4603c1.png">

