### PR TITLE
feature: fetch latest weights in distributed learning

### DIFF
--- a/lib/python/flame/mode/message.py
+++ b/lib/python/flame/mode/message.py
@@ -28,3 +28,6 @@ class MessageType(Enum):
 
     # a digest of all the workers in distributed learning
     MEMBER_DIGEST = 5
+    RING_WEIGHTS = 6 # global model weights in distributed learning
+    NEW_TRAINER = 7 # sending message for the arrival of a new trainer
+    IS_COMMITTER = 8 # is a trainer responsible to send weights to a new trainer in distributed learning


### PR DESCRIPTION
This commit allows a new trainer to fetch the latest global weight of distributed learning. The weight can either be 1) from the global weights produced by the ring all-reduce algorithm or 2) from a single trainer if there is only one trainer previsouly. Either case the trainer that holds the current best weights will be the committer.

type | file | changes
-- | -- | --
modified | lib/python/flame/mode/distributed/trainer.py | use existing communication channel to fetch latest weights
modified | lib/python/flame/mode/message.py |  add a new message type