### PR TITLE
fix: private dns support in linux fiab env

### DIFF
--- a/fiab/Vagrantfile
+++ b/fiab/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "myungjin-lee/flame"
+  config.vm.box = "ubuntu/focal64"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder "../", "/flame"
@@ -10,26 +10,7 @@ Vagrant.configure("2") do |config|
     vb.cpus = 2
   end
 
-  # define controller
-  config.vm.define "controller" do |controller|
-    controller.vm.hostname = "controller"
-    controller.vm.network :private_network, ip: "192.168.3.2"
-
-    # 8888: access to vernemq UI
-    controller.vm.network "forwarded_port", guest: 8888, host: 8880,
-                          auto_correct: true
-  end
-
-  # define workers
-  N = 2
-#   if ARGV[0] == 'up'
-#       print "Input number of worker nodes: "
-#       N = STDIN.gets.chomp.to_i
-#   end
-  (1..N).each do |i|
-    config.vm.define "worker#{i}" do |worker|
-      worker.vm.hostname = "worker#{i}"
-      worker.vm.network :private_network, ip: "192.168.3.#{10+i}"
-    end
+  config.vm.define "node" do |node|
+    node.vm.hostname = "flame"
   end
 end

--- a/fiab/bootstrap.sh
+++ b/fiab/bootstrap.sh
@@ -16,53 +16,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-function controller {
-    sudo systemctl enable vernemq
-    sudo systemctl start vernemq
-}
-
-function worker {
+function setup {
     # do something
     cat /dev/null
 }
 
-function setup {
-    sudo apt-get update
-    sudo apt-get upgrade
-    sudo apt-get install build-essential -y
-
-    # go installation
-    wget https://golang.org/dl/go1.16.6.linux-amd64.tar.gz
-    sudo tar -C /usr/local/ -xzf go1.16.6.linux-amd64.tar.gz
-    echo 'export PATH=$PATH:/usr/local/go/bin' >> /home/vagrant/.bashrc
-    source /home/vagrant/.bashrc
-
-    # python
-    sudo apt install software-properties-common -y
-    sudo add-apt-repository ppa:deadsnakes/ppa -y
-    sudo apt-get update -y
-    sudo apt-get install python3.9 python3.9-venv python3.9-dev python3.9-gdbm python3-pip -y
-    sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
-
-    # python packages
-    pip3 install paho-mqtt cloudpickle tensorflow torch torchvision scikit-learn
-
-    # Printing software versions for verification
-    echo -e "\n\n"
-    echo "Software version"
-    echo "- - - - - - - - - "
-    go version
-    python3 --version
-}
-
 function main {
-    # setup
-
-    if [ `hostname` == "controller" ]; then
-      controller
-    else
-      worker
-    fi
+    setup
 }
 
 main

--- a/fiab/flame.sh
+++ b/fiab/flame.sh
@@ -21,6 +21,11 @@ RELEASE_NAME=flame
 FILE_OF_INTEREST=helm-chart/values.yaml
 LINES_OF_INTEREST="27,34"
 
+SED_MAC_FIX=
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    SED_MAC_FIX=\'\'
+fi
+
 function init {
     cd helm-chart
     helm dependency update
@@ -53,20 +58,18 @@ function start {
     echo "mongodb pods are ready; working on enabling roadbalancer for mongodb..."
     # To enable external access for mongodb,
     # uncomment the lines of interest and upgrade the release
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	sed -i -e "$LINES_OF_INTEREST"" s/^  # /  /" $FILE_OF_INTEREST
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-	sed -i '' -e "$LINES_OF_INTEREST"" s/^  # /  /" $FILE_OF_INTEREST
-    fi
+    sed -i $SED_MAC_FIX -e "$LINES_OF_INTEREST"" s/^  # /  /" $FILE_OF_INTEREST
+    
 
     helm upgrade --namespace $RELEASE_NAME $RELEASE_NAME helm-chart/
     
     # comment the lines of interest
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	sed -i -e "$LINES_OF_INTEREST"" s/^  /  # /" $FILE_OF_INTEREST
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-	sed -i '' -e "$LINES_OF_INTEREST"" s/^  /  # /" $FILE_OF_INTEREST
-    fi
+    sed -i $SED_MAC_FIX -e "$LINES_OF_INTEREST"" s/^  /  # /" $FILE_OF_INTEREST
+
+    # in mac os, sed somehow creates a backup file whose name ends
+    # with '' (SED_MAX_FIX string). couldn't figure out why.
+    # as a workaround, delete the backup file
+    rm -f $FILE_OF_INTEREST$SED_MAC_FIX
 
     echo "done"
 }
@@ -75,15 +78,10 @@ function post_start_config {
     minikube_ip=$(minikube ip)
 
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	# Linux OS with resolvconf is assumed
-	# not completely tested
-	resolver_file=/etc/resolvconf/resolv.conf.d/base
-	echo "search flame.test" >> $resolver_file
-	echo "nameserver $minikube_ip" >> $resolver_file
-	echo "timeout 5" >> $resolver_file
-
-	sudo resolvconf -u
-	systemctl disable --now resolvconf.service
+	resolver_file=/etc/systemd/resolved.conf
+	sudo sed -i "s/^#DNS=/DNS=$minikube_ip/g" $resolver_file
+	sudo sed -i "s/^#Domains=/Domains=~flame.test/g" $resolver_file
+	sudo systemctl restart systemd-resolved
     elif [[ "$OSTYPE" == "darwin"* ]]; then
 	resolver_file=/etc/resolver/flame-test
 	echo "domain flame.test" | sudo tee $resolver_file > /dev/null
@@ -97,11 +95,7 @@ function post_start_config {
     # step 1: save the current entry
     kubectl get configmap coredns -n kube-system -o json | jq -r '.data."Corefile"' > $tmp_file
     # step 2: remove empty lines
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	sed -i '/^$/d' $tmp_file
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-	sed -i '' '/^$/d' $tmp_file
-    fi
+    sed -i $SED_MAC_FIX '/^$/d' $tmp_file
 
     # step 3: append the dns entry for flame.test domain at the end of file
     echo "flame.test:53 {" | tee -a $tmp_file > /dev/null
@@ -119,7 +113,7 @@ function post_start_config {
 	    --type merge \
 	    -p "$(cat $tmp_file)"
 
-    rm -f $tmp_file
+    rm -f $tmp_file $tmp_file$SED_MAC_FIX
 }
 
 function stop {
@@ -146,39 +140,25 @@ function post_stop_cleanup {
     minikube_ip=$(minikube ip)
 
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	# Linux OS with resolvconf is assumed
-	# not completely tested
-	resolver_file=/etc/resolvconf/resolv.conf.d/base
-	sudo sed -i '/search flame.test/d' $resolver_file
-	sudo sed -i '/nameserver $minikube_ip/d' $resolver_file
-	sudo sed -i '/timeout 5/d' $resolver_file
-
-	sudo resolvconf -u
-	systemctl enable --now resolvconf.service
+	resolver_file=/etc/systemd/resolved.conf
+	sudo sed -i "s/^DNS=$minikube_ip/#DNS=/g" $resolver_file
+	sudo sed -i "s/^Domains=~flame.test/#Domains=/g" $resolver_file
+	sudo systemctl restart systemd-resolved
     elif [[ "$OSTYPE" == "darwin"* ]]; then
 	resolver_file=/etc/resolver/flame-test
 	sudo rm -f $resolver_file
     fi
-
 
     # remove dns entry for flame.test domain in coredns
     tmp_file=tmp.bak
     # step 1: save the current entry
     kubectl get configmap coredns -n kube-system -o json | jq -r '.data."Corefile"' > $tmp_file
 
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	sed -i '/^$/d' $tmp_file
-	# remove last five lines
-	for i in {1..5}; do
-	    sed -i '$d' $tmp_file
-	done
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-	sed -i '' '/^$/d' $tmp_file
-	# remove last five lines
-	for i in {1..5}; do
-	    sed -i '' '$d' $tmp_file
-	done
-    fi
+    sed -i $SED_MAC_FIX '/^$/d' $tmp_file
+    # remove last five lines
+    for i in {1..5}; do
+	sed -i $SED_MAC_FIX '$d' $tmp_file
+    done
 
     # step 4: create patch file
     echo "{\"data\": {\"Corefile\": $(jq -R -s < $tmp_file)}}" > $tmp_file
@@ -189,7 +169,7 @@ function post_stop_cleanup {
 	    --type merge \
 	    -p "$(cat $tmp_file)"
 
-    rm -f $tmp_file
+    rm -f $tmp_file $tmp_file$SED_MAC_FIX
 }
 
 function main {


### PR DESCRIPTION
The private dns support under a linux fiab env is broken. It is fixed
now under Ubuntu 20.04 LTS. Testing is done using Ubuntu 20.04 LTS
under vagrant environment.