### PR TITLE
Prepending API endpoints involving user to prevent mismatches with future endpoints

### DIFF
--- a/api/dataset_api.partials.yml
+++ b/api/dataset_api.partials.yml
@@ -56,7 +56,7 @@
     tags:
       - datasets
 
-/{user}/datasets:
+/users/{user}/datasets:
   ########################################
   # Get the meta info on all datasets owned by user
   ########################################
@@ -140,7 +140,7 @@
     tags:
       - datasets
 
-/{user}/datasets/{datasetId}:
+/users/{user}/datasets/{datasetId}:
   ########################################
   # Get dataset meta info via ID
   ########################################

--- a/api/design_api.partials.yml
+++ b/api/design_api.partials.yml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-/{user}/designs:
+/users/{user}/designs:
   #------------------------------------#
   # Get Template - get list of all designs
   #------------------------------------#
@@ -98,7 +98,7 @@
     tags:
       - designs
 
-/{user}/designs/{designId}:
+/users/{user}/designs/{designId}:
   #------------------------------------#
   # Get Design via ID
   #------------------------------------#
@@ -146,7 +146,7 @@
     tags:
       - designs
 
-/{user}/designs/{designId}/schemas:
+/users/{user}/designs/{designId}/schemas:
   #------------------------------------#
   # Get All Design Schemas
   #------------------------------------#
@@ -226,7 +226,7 @@
     tags:
       - designSchemas
 
-/{user}/designs/{designId}/schemas/{version}:
+/users/{user}/designs/{designId}/schemas/{version}:
   #------------------------------------#
   # Get Design Schema
   #------------------------------------#
@@ -322,7 +322,7 @@
     tags:
       - designSchemas
 
-/{user}/designs/{designId}/codes:
+/users/{user}/designs/{designId}/codes:
   #------------------------------------#
   # Upload Code Zip
   #------------------------------------#
@@ -363,7 +363,7 @@
     tags:
       - designCodes
 
-/{user}/designs/{designId}/codes/{version}:
+/users/{user}/designs/{designId}/codes/{version}:
   #------------------------------------#
   # Get Code Zip
   #------------------------------------#

--- a/api/job_api.partials.yml
+++ b/api/job_api.partials.yml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-/{user}/jobs:
+/users/{user}/jobs:
   ########################################
   # Create new job
   ########################################
@@ -96,7 +96,7 @@
               $ref: '#/components/schemas/Error'
         description: unexpected error
 
-/{user}/jobs/{jobId}:
+/users/{user}/jobs/{jobId}:
   ########################################
   # Get job specification given an ID
   ########################################
@@ -217,7 +217,7 @@
               $ref: '#/components/schemas/Error'
         description: unexpected error
 
-/{user}/jobs/{jobId}/status:
+/users/{user}/jobs/{jobId}/status:
   ########################################
   # Get job status
   ########################################
@@ -299,7 +299,7 @@
               $ref: '#/components/schemas/Error'
         description: unexpected error
 
-/{user}/jobs/{jobId}/tasks/{taskId}:
+/users/{user}/jobs/{jobId}/tasks/{taskId}:
   ########################################
   # Get info of a task in a job
   ########################################
@@ -349,7 +349,7 @@
               $ref: '#/components/schemas/Error'
         description: unexpected error
 
-/{user}/jobs/{jobId}/tasks:
+/users/{user}/jobs/{jobId}/tasks:
   ########################################
   # Get info of tasks in a job
   ########################################

--- a/pkg/openapi/api_datasets.go
+++ b/pkg/openapi/api_datasets.go
@@ -49,7 +49,7 @@ func (c *DatasetsApiController) Routes() Routes {
 		{
 			"CreateDataset",
 			strings.ToUpper("Post"),
-			"/{user}/datasets",
+			"/users/{user}/datasets",
 			c.CreateDataset,
 		},
 		{
@@ -61,19 +61,19 @@ func (c *DatasetsApiController) Routes() Routes {
 		{
 			"GetDataset",
 			strings.ToUpper("Get"),
-			"/{user}/datasets/{datasetId}",
+			"/users/{user}/datasets/{datasetId}",
 			c.GetDataset,
 		},
 		{
 			"GetDatasets",
 			strings.ToUpper("Get"),
-			"/{user}/datasets",
+			"/users/{user}/datasets",
 			c.GetDatasets,
 		},
 		{
 			"UpdateDataset",
 			strings.ToUpper("Put"),
-			"/{user}/datasets/{datasetId}",
+			"/users/{user}/datasets/{datasetId}",
 			c.UpdateDataset,
 		},
 	}

--- a/pkg/openapi/api_design_codes.go
+++ b/pkg/openapi/api_design_codes.go
@@ -50,19 +50,19 @@ func (c *DesignCodesApiController) Routes() Routes {
 		{
 			"CreateDesignCode",
 			strings.ToUpper("Post"),
-			"/{user}/designs/{designId}/codes",
+			"/users/{user}/designs/{designId}/codes",
 			c.CreateDesignCode,
 		},
 		{
 			"GetDesignCode",
 			strings.ToUpper("Get"),
-			"/{user}/designs/{designId}/codes/{version}",
+			"/users/{user}/designs/{designId}/codes/{version}",
 			c.GetDesignCode,
 		},
 		{
 			"UpdateDesignCode",
 			strings.ToUpper("Put"),
-			"/{user}/designs/{designId}/codes/{version}",
+			"/users/{user}/designs/{designId}/codes/{version}",
 			c.UpdateDesignCode,
 		},
 	}

--- a/pkg/openapi/api_design_schemas.go
+++ b/pkg/openapi/api_design_schemas.go
@@ -49,25 +49,25 @@ func (c *DesignSchemasApiController) Routes() Routes {
 		{
 			"CreateDesignSchema",
 			strings.ToUpper("Post"),
-			"/{user}/designs/{designId}/schemas",
+			"/users/{user}/designs/{designId}/schemas",
 			c.CreateDesignSchema,
 		},
 		{
 			"GetDesignSchema",
 			strings.ToUpper("Get"),
-			"/{user}/designs/{designId}/schemas/{version}",
+			"/users/{user}/designs/{designId}/schemas/{version}",
 			c.GetDesignSchema,
 		},
 		{
 			"GetDesignSchemas",
 			strings.ToUpper("Get"),
-			"/{user}/designs/{designId}/schemas",
+			"/users/{user}/designs/{designId}/schemas",
 			c.GetDesignSchemas,
 		},
 		{
 			"UpdateDesignSchema",
 			strings.ToUpper("Put"),
-			"/{user}/designs/{designId}/schemas/{version}",
+			"/users/{user}/designs/{designId}/schemas/{version}",
 			c.UpdateDesignSchema,
 		},
 	}

--- a/pkg/openapi/api_designs.go
+++ b/pkg/openapi/api_designs.go
@@ -49,19 +49,19 @@ func (c *DesignsApiController) Routes() Routes {
 		{
 			"CreateDesign",
 			strings.ToUpper("Post"),
-			"/{user}/designs",
+			"/users/{user}/designs",
 			c.CreateDesign,
 		},
 		{
 			"GetDesign",
 			strings.ToUpper("Get"),
-			"/{user}/designs/{designId}",
+			"/users/{user}/designs/{designId}",
 			c.GetDesign,
 		},
 		{
 			"GetDesigns",
 			strings.ToUpper("Get"),
-			"/{user}/designs",
+			"/users/{user}/designs",
 			c.GetDesigns,
 		},
 	}

--- a/pkg/openapi/api_jobs.go
+++ b/pkg/openapi/api_jobs.go
@@ -71,31 +71,31 @@ func (c *JobsApiController) Routes() Routes {
 		{
 			"CreateJob",
 			strings.ToUpper("Post"),
-			"/{user}/jobs",
+			"/users/{user}/jobs",
 			c.CreateJob,
 		},
 		{
 			"DeleteJob",
 			strings.ToUpper("Delete"),
-			"/{user}/jobs/{jobId}",
+			"/users/{user}/jobs/{jobId}",
 			c.DeleteJob,
 		},
 		{
 			"GetJob",
 			strings.ToUpper("Get"),
-			"/{user}/jobs/{jobId}",
+			"/users/{user}/jobs/{jobId}",
 			c.GetJob,
 		},
 		{
 			"GetJobStatus",
 			strings.ToUpper("Get"),
-			"/{user}/jobs/{jobId}/status",
+			"/users/{user}/jobs/{jobId}/status",
 			c.GetJobStatus,
 		},
 		{
 			"GetJobs",
 			strings.ToUpper("Get"),
-			"/{user}/jobs",
+			"/users/{user}/jobs",
 			c.GetJobs,
 		},
 		{
@@ -107,25 +107,25 @@ func (c *JobsApiController) Routes() Routes {
 		{
 			"GetTaskInfo",
 			strings.ToUpper("Get"),
-			"/{user}/jobs/{jobId}/tasks/{taskId}",
+			"/users/{user}/jobs/{jobId}/tasks/{taskId}",
 			c.GetTaskInfo,
 		},
 		{
 			"GetTasksInfo",
 			strings.ToUpper("Get"),
-			"/{user}/jobs/{jobId}/tasks",
+			"/users/{user}/jobs/{jobId}/tasks",
 			c.GetTasksInfo,
 		},
 		{
 			"UpdateJob",
 			strings.ToUpper("Put"),
-			"/{user}/jobs/{jobId}",
+			"/users/{user}/jobs/{jobId}",
 			c.UpdateJob,
 		},
 		{
 			"UpdateJobStatus",
 			strings.ToUpper("Put"),
-			"/{user}/jobs/{jobId}/status",
+			"/users/{user}/jobs/{jobId}/status",
 			c.UpdateJobStatus,
 		},
 		{

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -75,38 +75,38 @@ const (
 
 var URI = map[string]string{
 	// Dataset
-	CreateDatasetEndPoint:  "/{{.user}}/datasets",
-	GetDatasetEndPoint:     "/{{.user}}/datasets/{{.datasetId}}",
-	GetDatasetsEndPoint:    "/{{.user}}/datasets/?limit={{.limit}}",
+	CreateDatasetEndPoint:  "/users/{{.user}}/datasets",
+	GetDatasetEndPoint:     "/users/{{.user}}/datasets/{{.datasetId}}",
+	GetDatasetsEndPoint:    "/users/{{.user}}/datasets/?limit={{.limit}}",
 	GetAllDatasetsEndPoint: "/datasets/?limit={{.limit}}",
 
 	// Design
-	CreateDesignEndPoint: "/{{.user}}/designs",
-	GetDesignEndPoint:    "/{{.user}}/designs/{{.designId}}",
-	GetDesignsEndPoint:   "/{{.user}}/designs/?limit={{.limit}}",
+	CreateDesignEndPoint: "/users/{{.user}}/designs",
+	GetDesignEndPoint:    "/users/{{.user}}/designs/{{.designId}}",
+	GetDesignsEndPoint:   "/users/{{.user}}/designs/?limit={{.limit}}",
 
 	// Design schema
-	CreateDesignSchemaEndPoint: "/{{.user}}/designs/{{.designId}}/schemas",
-	GetDesignSchemaEndPoint:    "/{{.user}}/designs/{{.designId}}/schemas/{{.version}}",
-	GetDesignSchemasEndPoint:   "/{{.user}}/designs/{{.designId}}/schemas",
-	UpdateDesignSchemaEndPoint: "/{{.user}}/designs/{{.designId}}/schemas/{{.version}}",
+	CreateDesignSchemaEndPoint: "/users/{{.user}}/designs/{{.designId}}/schemas",
+	GetDesignSchemaEndPoint:    "/users/{{.user}}/designs/{{.designId}}/schemas/{{.version}}",
+	GetDesignSchemasEndPoint:   "/users/{{.user}}/designs/{{.designId}}/schemas",
+	UpdateDesignSchemaEndPoint: "/users/{{.user}}/designs/{{.designId}}/schemas/{{.version}}",
 
 	// Design Code
-	CreateDesignCodeEndPoint: "/{{.user}}/designs/{{.designId}}/codes",
-	GetDesignCodeEndPoint:    "/{{.user}}/designs/{{.designId}}/codes/{{.version}}",
-	UpdateDesignCodeEndPoint: "/{{.user}}/designs/{{.designId}}/codes/{{.version}}",
+	CreateDesignCodeEndPoint: "/users/{{.user}}/designs/{{.designId}}/codes",
+	GetDesignCodeEndPoint:    "/users/{{.user}}/designs/{{.designId}}/codes/{{.version}}",
+	UpdateDesignCodeEndPoint: "/users/{{.user}}/designs/{{.designId}}/codes/{{.version}}",
 
 	// Job
-	CreateJobEndpoint:       "/{{.user}}/jobs",
-	GetJobEndPoint:          "/{{.user}}/jobs/{{.jobId}}",
-	GetJobsEndPoint:         "/{{.user}}/jobs/?limit={{.limit}}",
-	GetJobStatusEndPoint:    "/{{.user}}/jobs/{{.jobId}}/status",
-	GetTasksInfoEndpoint:    "/{{.user}}/jobs/{{.jobId}}/tasks/?limit={{.limit}}",
-	GetTaskInfoEndpoint:     "/{{.user}}/jobs/{{.jobId}}/tasks/{{.taskId}}",
-	UpdateJobEndPoint:       "/{{.user}}/jobs/{{.jobId}}",
-	DeleteJobEndPoint:       "/{{.user}}/jobs/{{.jobId}}",
-	ChangeJobSchemaEndPoint: "/{{.user}}/jobs/{{.jobId}}/schema/{{.schemaId}}/design/{{.designId}}",
-	UpdateJobStatusEndPoint: "/{{.user}}/jobs/{{.jobId}}/status",
+	CreateJobEndpoint:       "/users/{{.user}}/jobs",
+	GetJobEndPoint:          "/users/{{.user}}/jobs/{{.jobId}}",
+	GetJobsEndPoint:         "/users/{{.user}}/jobs/?limit={{.limit}}",
+	GetJobStatusEndPoint:    "/users/{{.user}}/jobs/{{.jobId}}/status",
+	GetTasksInfoEndpoint:    "/users/{{.user}}/jobs/{{.jobId}}/tasks/?limit={{.limit}}",
+	GetTaskInfoEndpoint:     "/users/{{.user}}/jobs/{{.jobId}}/tasks/{{.taskId}}",
+	UpdateJobEndPoint:       "/users/{{.user}}/jobs/{{.jobId}}",
+	DeleteJobEndPoint:       "/users/{{.user}}/jobs/{{.jobId}}",
+	ChangeJobSchemaEndPoint: "/users/{{.user}}/jobs/{{.jobId}}/schema/{{.schemaId}}/design/{{.designId}}",
+	UpdateJobStatusEndPoint: "/users/{{.user}}/jobs/{{.jobId}}/status",
 
 	// Task
 	GetTaskEndpoint:          "/jobs/{{.jobId}}/{{.taskId}}/task/?key={{.key}}",


### PR DESCRIPTION
We will be adding new API endpoints for multi-cluster support. These new API endpoints will follow the pattern `/computes/{..}`. However many existing API endpoints follow the pattern `/{user}/{..}`. Thus, there is a possible issue of incorrect api resolution when a `{user}` name is `computes`. To clean up the endpoints and to avoid such cases, endpoints containing `/{users}/` are prepended with a static `/users/`. This will ensure correct end-point resolution.