### PR TITLE
typo: use correct func tags for distributed learning

### DIFF
--- a/examples/distributed_training/schema.json
+++ b/examples/distributed_training/schema.json
@@ -9,22 +9,22 @@
 	}
     ],
     "channels": [
-	{
-	    "name": "param-channel",
-	    "description": "Model update is sent from trainer to other trainers",
-	    "pair": [
-			"trainer",
-			"trainer"
-	    ],
-	    "groupBy": {
-			"type": "tag",
-			"value": [
-		    	"default/us"
-		]
-	    },
+        {
+            "description": "Model update is sent from a trainer to another trainer",
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default/us"
+                ]
+            },
+            "name": "param-channel",
+            "pair": [
+                "trainer",
+                "trainer"
+            ],
 	    "funcTags": {
-			"trainer": ["fetch", "upload"]
-	    }
-	}
+                "trainer": ["ring_allreduce"]
+            }
+        }
     ]
 }


### PR DESCRIPTION
Previously, the distributed learning topology works with python library but doesn't work with flame system. It turns out to be a simple typo error. Now fixed.

type | file | changes
-- | -- | --
modified | examples/distributed_training/schema.json | update func tags in schema