### PR TITLE
fix: message mixed up in distributed learning mode

### DIFF
--- a/lib/python/flame/examples/dist_mnist/trainer/config1.json
+++ b/lib/python/flame/examples/dist_mnist/trainer/config1.json
@@ -45,7 +45,7 @@
     },
     "registry": {
 	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+	"uri": "http://mlflow.flame.test"
     },
     "selector": {
 	    "sort": "default",

--- a/lib/python/flame/examples/dist_mnist/trainer/config2.json
+++ b/lib/python/flame/examples/dist_mnist/trainer/config2.json
@@ -45,7 +45,7 @@
     },
     "registry": {
 	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+	"uri": "http://mlflow.flame.test"
     },
     "selector": {
 	    "sort": "default",

--- a/lib/python/flame/examples/dist_mnist/trainer/config3.json
+++ b/lib/python/flame/examples/dist_mnist/trainer/config3.json
@@ -45,7 +45,7 @@
     },
     "registry": {
 	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+	"uri": "http://mlflow.flame.test"
     },
     "selector": {
 	    "sort": "default",


### PR DESCRIPTION
During the member check, there is a high chance to receive weights
message because other workers started ring all-reduce process while
a trainer is in a member check loop. In such a case, the current code
will delcare failure of the membership check. This creates an
inconsistent agreement among workers, meaning that some think they are
in a ring and some others don't. To address the issue, we reinstate
the peek statement.

In addition, some cosmetric reformatting is done.