### PR TITLE
Initial implementation for deployer registration

### DIFF
--- a/api/computes_api.partials.yml
+++ b/api/computes_api.partials.yml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-/computes/{compute}:
+/computes:
   ########################################
   # Register a new compute cluster
   ########################################
@@ -23,15 +23,6 @@
     summary: Register a new compute cluster
     tags:
       - computes
-    parameters:
-      - name: compute
-        description: deployer id of compute cluster
-        in: path
-        schema:
-          type: string
-        style: simple
-        explode: false
-        required: true
     requestBody:
       content:
         application/json:
@@ -49,6 +40,7 @@
               $ref: '#/components/schemas/Error'
         description: unexpected error
 
+/computes/{compute}:
   ########################################
   # Get the status of a compute cluster
   ########################################

--- a/api/computes_components.partials.yml
+++ b/api/computes_components.partials.yml
@@ -21,24 +21,19 @@ ComputeSpec:
   description: Compute specification
   type: object
   properties:
-    deployerId:
-      type: string
     adminId:
       type: string
     region:
       type: string
-    computeId:
-      type: string
     apiKey:
       type: string
-  required:
-    - deployerId
+    computeId:
+      type: string
   example:
-    deployerId: "60d0d66716af13b787d9ef0a"
     adminId: "admin1"
     region: "us-east"
-    computeId: "1"
     apiKey: "892nsfd2ds82"
+    computeId: "62cdd50e5e28e1473c3768fc"
 
 ########################################
 # Compute status
@@ -47,27 +42,19 @@ ComputeStatus:
   description: Cluster compute status
   type: object
   properties:
-    deployerId:
-      type: string
-    state:
-      $ref: '#/components/schemas/ComputeState'
     registeredAt:
       type: string
       format: date-time
+    state:
+      $ref: '#/components/schemas/ComputeState'
     updatedAt:
       type: string
       format: date-time
-    region:
-      type: string
-    computeId:
-      type: string
-    computeSpec:
-      type: string
+    spec:
+      $ref: '#/components/schemas/ComputeSpec'
   required:
-    - deployerId
     - state
-    - region
-    - computeId
+    - spec
 
 ########################################
 # Compute state

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -102,6 +102,7 @@ func (c *Controller) serveRestApi() {
 		openapi.NewDesignCodesApiController(controller.NewDesignCodesApiService(c.dbService)),
 		openapi.NewDesignSchemasApiController(controller.NewDesignSchemasApiService(c.dbService)),
 		openapi.NewJobsApiController(controller.NewJobsApiService(c.dbService, c.jobEventQ, c.jobBuilder)),
+		openapi.NewComputesApiController(controller.NewComputesApiService(c.dbService)),
 	}
 
 	router := openapi.NewRouter(apiRouters...)

--- a/cmd/controller/app/database/db_interfaces.go
+++ b/cmd/controller/app/database/db_interfaces.go
@@ -30,6 +30,7 @@ type DBService interface {
 	DesignService
 	JobService
 	TaskService
+	ComputeService
 }
 
 // DatasetService is an interface that defines a collection of APIs related to dataset
@@ -79,4 +80,9 @@ type TaskService interface {
 	SetTaskDirtyFlag(string, bool) error
 	UpdateTaskStateByFilter(string, openapi.JobState, map[string]interface{}) error
 	UpdateTaskStatus(string, string, openapi.TaskStatus) error
+}
+
+// ComputeService is an interface that defines a collection of APIs related to computes
+type ComputeService interface {
+	RegisterCompute(openapi.ComputeSpec) (openapi.ComputeStatus, error)
 }

--- a/cmd/controller/app/database/mongodb/compute.go
+++ b/cmd/controller/app/database/mongodb/compute.go
@@ -14,4 +14,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package app
+package mongodb
+
+import (
+	"github.com/cisco-open/flame/pkg/openapi"
+)
+
+// RegisterCompute creates a new cluster compute specification and returns ComputeStatus
+func (db *MongoService) RegisterCompute(computeSpec openapi.ComputeSpec) (openapi.ComputeStatus, error) {
+	// TODO implement the method
+
+	return openapi.ComputeStatus{}, nil
+}
+
+// UpdateComputeStatus update compute cluster status
+func (db *MongoService) UpdateComputeStatus(computeId string, computeStatus openapi.ComputeStatus) error {
+	// TODO implement the method
+
+	return nil
+}

--- a/cmd/deployer/app/register.go
+++ b/cmd/deployer/app/register.go
@@ -1,0 +1,81 @@
+// Copyright 2022 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"crypto/tls"
+	"net/http"
+	"os"
+
+	"go.uber.org/zap"
+
+	"github.com/cisco-open/flame/pkg/openapi"
+	"github.com/cisco-open/flame/pkg/restapi"
+)
+
+type ComputeResource struct {
+	apiserverEp string
+	name        string
+	spec        openapi.ComputeSpec
+	registered  bool
+}
+
+func NewCompute(apiserverEp string, computeSpec openapi.ComputeSpec, bInsecure bool, bPlain bool) (*ComputeResource, error) {
+	name, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+
+	if bPlain {
+	} else {
+		tlsCfg := &tls.Config{}
+		if bInsecure {
+			zap.S().Warn("Warning: allow insecure connection\n")
+
+			tlsCfg.InsecureSkipVerify = true
+			http.DefaultTransport.(*http.Transport).TLSClientConfig = tlsCfg
+		}
+	}
+
+	compute := &ComputeResource{
+		apiserverEp: apiserverEp,
+		name:        name,
+		spec:        computeSpec,
+		registered:  false,
+	}
+
+	return compute, nil
+}
+
+func (compute *ComputeResource) RegisterNewCompute() error {
+	// construct URL
+	uriMap := map[string]string{}
+	url := restapi.CreateURL(compute.apiserverEp, restapi.RegisterComputeEndpoint, uriMap)
+
+	code, resp, err := restapi.HTTPPost(url, compute.spec, "application/json")
+	if err != nil || restapi.CheckStatusCode(code) != nil {
+		zap.S().Errorf("Failed to register compute, sent computeSpec: %v, resp: %v, code: %d, err: %v",
+			compute.spec, string(resp), code, err)
+		return err
+	}
+
+	zap.S().Infof("Success in registering new compute, sent obj: %v, resp: %v, code: %d",
+		compute.spec, string(resp), code)
+	compute.registered = true
+
+	return nil
+}

--- a/cmd/deployer/cmd/root.go
+++ b/cmd/deployer/cmd/root.go
@@ -15,3 +15,78 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cisco-open/flame/cmd/deployer/app"
+	"github.com/cisco-open/flame/pkg/openapi"
+	"github.com/cisco-open/flame/pkg/util"
+)
+
+const (
+	argApiserver = "apiserver"
+
+	optionInsecure = "insecure"
+	optionPlain    = "plain"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   util.Deployer,
+	Short: util.ProjectName + " Deployer",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		flags := cmd.Flags()
+
+		apiserver, err := flags.GetString(argApiserver)
+		if err != nil {
+			return err
+		}
+		if len(strings.Split(apiserver, ":")) != util.NumTokensInRestEndpoint {
+			return fmt.Errorf("incorrect format for apiserver endpoint: %s", apiserver)
+		}
+
+		bInsecure, _ := flags.GetBool(optionInsecure)
+		bPlain, _ := flags.GetBool(optionPlain)
+
+		if bInsecure && bPlain {
+			err = fmt.Errorf("options --%s and --%s are incompatible; enable one of them", optionInsecure, optionPlain)
+			return err
+		}
+
+		// Pass more values to NewCompute using
+		computeSpec := openapi.ComputeSpec{
+			AdminId:   "admin1",
+			Region:    "us-east",
+			ComputeId: "1",
+			ApiKey:    "temp",
+		}
+
+		compute, err := app.NewCompute(apiserver, computeSpec, bInsecure, bPlain)
+		if err != nil {
+			return err
+		}
+
+		if err := compute.RegisterNewCompute(); err != nil {
+			err = fmt.Errorf("error from RegisterNewCompute: %s", err)
+			return err
+		}
+
+		select {}
+	},
+}
+
+func init() {
+	defaultApiServerEp := fmt.Sprintf("http://0.0.0.0:%d", util.ApiServerRestApiPort)
+	rootCmd.Flags().StringP(argApiserver, "a", defaultApiServerEp, "API server endpoint")
+	rootCmd.MarkFlagRequired(argApiserver)
+
+	rootCmd.PersistentFlags().Bool(optionInsecure, false, "Allow insecure connection")
+	rootCmd.PersistentFlags().Bool(optionPlain, false, "Allow unencrypted connection")
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}

--- a/cmd/deployer/cmd/root_test.go
+++ b/cmd/deployer/cmd/root_test.go
@@ -14,4 +14,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package app
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cisco-open/flame/cmd/deployer/app"
+	"github.com/cisco-open/flame/pkg/openapi"
+)
+
+var (
+	testComputeSpec = openapi.ComputeSpec{
+		AdminId: "admin1",
+		Region:  "us-east",
+		ApiKey:  "temp",
+	}
+
+	apiargApiserver = "apiserver.flame.test"
+	bInsecure       = true
+	bPlain          = false
+)
+
+func TestNewCompute(t *testing.T) {
+	compute, err := app.NewCompute(apiargApiserver, testComputeSpec, bInsecure, bPlain)
+	assert.NotNil(t, compute)
+	assert.Nil(t, err)
+}

--- a/cmd/deployer/main.go
+++ b/cmd/deployer/main.go
@@ -16,15 +16,21 @@
 
 package main
 
-import "time"
+import (
+	"os"
+
+	"go.uber.org/zap"
+
+	"github.com/cisco-open/flame/cmd/deployer/cmd"
+	"github.com/cisco-open/flame/pkg/util"
+)
 
 func main() {
-	go forever()
-	select {} // block forever
-}
+	loggerMgr := util.InitZapLog(util.Deployer)
+	zap.ReplaceGlobals(loggerMgr)
+	defer loggerMgr.Sync()
 
-func forever() {
-	for {
-		time.Sleep(time.Second)
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
 	}
 }

--- a/fiab/helm-chart/templates/deployer-deployment.yaml
+++ b/fiab/helm-chart/templates/deployer-deployment.yaml
@@ -31,7 +31,10 @@ spec:
         app: {{ .Release.Name }}-deployer
     spec:
       containers:
-        - args: []
+        - args:
+          - --apiserver
+          - "https://{{ .Values.frontDoorUrl.apiserver }}:443"
+          - --insecure
           command: ["/usr/bin/deployer"]
           image: {{ .Values.imageName }}:{{ .Values.imageTag }}
           imagePullPolicy: IfNotPresent

--- a/pkg/openapi/api.go
+++ b/pkg/openapi/api.go
@@ -106,7 +106,7 @@ type ComputesApiServicer interface {
 	DeleteCompute(context.Context, string) (ImplResponse, error)
 	GetComputeConfig(context.Context, string) (ImplResponse, error)
 	GetComputeStatus(context.Context, string) (ImplResponse, error)
-	RegisterCompute(context.Context, string, ComputeSpec) (ImplResponse, error)
+	RegisterCompute(context.Context, ComputeSpec) (ImplResponse, error)
 	UpdateCompute(context.Context, string, ComputeSpec) (ImplResponse, error)
 }
 

--- a/pkg/openapi/api_computes.go
+++ b/pkg/openapi/api_computes.go
@@ -87,7 +87,7 @@ func (c *ComputesApiController) Routes() Routes {
 		{
 			"RegisterCompute",
 			strings.ToUpper("Post"),
-			"/computes/{compute}",
+			"/computes",
 			c.RegisterCompute,
 		},
 		{
@@ -146,9 +146,6 @@ func (c *ComputesApiController) GetComputeStatus(w http.ResponseWriter, r *http.
 
 // RegisterCompute - Register a new compute cluster
 func (c *ComputesApiController) RegisterCompute(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	computeParam := params["compute"]
-
 	computeSpecParam := ComputeSpec{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
@@ -160,7 +157,7 @@ func (c *ComputesApiController) RegisterCompute(w http.ResponseWriter, r *http.R
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.RegisterCompute(r.Context(), computeParam, computeSpecParam)
+	result, err := c.service.RegisterCompute(r.Context(), computeSpecParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/pkg/openapi/controller/api_computes_service.go
+++ b/pkg/openapi/controller/api_computes_service.go
@@ -30,6 +30,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/cisco-open/flame/cmd/controller/app/database"
 	"github.com/cisco-open/flame/pkg/openapi"
 )
 
@@ -37,11 +38,14 @@ import (
 // This service should implement the business logic for every endpoint for the ComputesApi API.
 // Include any external packages or services that will be required by this service.
 type ComputesApiService struct {
+	dbService database.DBService
 }
 
 // NewComputesApiService creates a default api service
-func NewComputesApiService() openapi.ComputesApiServicer {
-	return &ComputesApiService{}
+func NewComputesApiService(dbService database.DBService) openapi.ComputesApiServicer {
+	return &ComputesApiService{
+		dbService: dbService,
+	}
 }
 
 // DeleteCompute - Delete compute cluster specification
@@ -96,8 +100,7 @@ func (s *ComputesApiService) GetComputeStatus(ctx context.Context, compute strin
 }
 
 // RegisterCompute - Register a new compute cluster
-func (s *ComputesApiService) RegisterCompute(ctx context.Context, compute string,
-	computeSpec openapi.ComputeSpec) (openapi.ImplResponse, error) {
+func (s *ComputesApiService) RegisterCompute(ctx context.Context, computeSpec openapi.ComputeSpec) (openapi.ImplResponse, error) {
 	// TODO - update RegisterCompute with the required logic for this service method.
 	// Add api_computes_service.go to the .openapi-generator-ignore to avoid overwriting
 	// this service implementation when updating open api generation.

--- a/pkg/openapi/model_compute_spec.go
+++ b/pkg/openapi/model_compute_spec.go
@@ -27,8 +27,6 @@ package openapi
 
 // ComputeSpec - Compute specification
 type ComputeSpec struct {
-	DeployerId string `json:"deployerId"`
-
 	AdminId string `json:"adminId,omitempty"`
 
 	Region string `json:"region,omitempty"`
@@ -40,15 +38,6 @@ type ComputeSpec struct {
 
 // AssertComputeSpecRequired checks if the required fields are not zero-ed
 func AssertComputeSpecRequired(obj ComputeSpec) error {
-	elements := map[string]interface{}{
-		"deployerId": obj.DeployerId,
-	}
-	for name, el := range elements {
-		if isZero := IsZeroValue(el); isZero {
-			return &RequiredError{Field: name}
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/openapi/model_compute_status.go
+++ b/pkg/openapi/model_compute_status.go
@@ -31,28 +31,20 @@ import (
 
 // ComputeStatus - Cluster compute status
 type ComputeStatus struct {
-	DeployerId string `json:"deployerId"`
+	RegisteredAt time.Time `json:"registeredAt,omitempty"`
 
 	State ComputeState `json:"state"`
 
-	RegisteredAt time.Time `json:"registeredAt,omitempty"`
-
 	UpdatedAt time.Time `json:"updatedAt,omitempty"`
 
-	Region string `json:"region"`
-
-	ComputeId string `json:"computeId"`
-
-	ComputeSpec string `json:"computeSpec,omitempty"`
+	Spec ComputeSpec `json:"spec"`
 }
 
 // AssertComputeStatusRequired checks if the required fields are not zero-ed
 func AssertComputeStatusRequired(obj ComputeStatus) error {
 	elements := map[string]interface{}{
-		"deployerId": obj.DeployerId,
-		"state":      obj.State,
-		"region":     obj.Region,
-		"computeId":  obj.ComputeId,
+		"state": obj.State,
+		"spec":  obj.Spec,
 	}
 	for name, el := range elements {
 		if isZero := IsZeroValue(el); isZero {
@@ -60,6 +52,9 @@ func AssertComputeStatusRequired(obj ComputeStatus) error {
 		}
 	}
 
+	if err := AssertComputeSpecRequired(obj.Spec); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -71,6 +71,13 @@ const (
 	// Keys for task
 	GetTaskEndpoint          = "GET_TASK"
 	UpdateTaskStatusEndPoint = "UPDATE_TASK_STATUS"
+
+	// Keys for computes endpoints
+	RegisterComputeEndpoint  = "REGISTER_COMPUTE"
+	GetComputeStatusEndpoint = "GET_COMPUTE_STATUS"
+	UpdateComputeEndpoint    = "UPDATE_COMPUTE"
+	DeleteComputeEndpoint    = "DELETE_COMPUTE"
+	GetComputeConfigEndpoint = "GET_COMPUTE_CONFIG"
 )
 
 var URI = map[string]string{
@@ -111,6 +118,13 @@ var URI = map[string]string{
 	// Task
 	GetTaskEndpoint:          "/jobs/{{.jobId}}/{{.taskId}}/task/?key={{.key}}",
 	UpdateTaskStatusEndPoint: "/jobs/{{.jobId}}/{{.taskId}}/task/status",
+
+	// Computes
+	RegisterComputeEndpoint:  "/computes",
+	GetComputeStatusEndpoint: "/computes/{{.compute}}",
+	UpdateComputeEndpoint:    "/computes/{{.compute}}",
+	DeleteComputeEndpoint:    "/computes/{{.compute}}",
+	GetComputeConfigEndpoint: "/computes/{{.compute}}/config",
 }
 
 func FromTemplate(skeleton string, inputMap map[string]string) (string, error) {


### PR DESCRIPTION
Includes functionality to register new compute cluster in flame. Since the mongodb implementation for compute registration is incomplete, this is a partial pr and does not include controller implementation for compute cluster registration.