### PR TITLE
Populating deployment config for deployer

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -102,7 +102,7 @@ func (c *Controller) serveRestApi() {
 		openapi.NewDesignCodesApiController(controller.NewDesignCodesApiService(c.dbService)),
 		openapi.NewDesignSchemasApiController(controller.NewDesignSchemasApiService(c.dbService)),
 		openapi.NewJobsApiController(controller.NewJobsApiService(c.dbService, c.jobEventQ, c.jobBuilder)),
-		openapi.NewComputesApiController(controller.NewComputesApiService(c.dbService)),
+		openapi.NewComputesApiController(controller.NewComputesApiService(c.dbService, c.jobParams)),
 	}
 
 	router := openapi.NewRouter(apiRouters...)

--- a/cmd/controller/app/database/db_interfaces.go
+++ b/cmd/controller/app/database/db_interfaces.go
@@ -67,6 +67,7 @@ type JobService interface {
 	UpdateJobStatus(string, string, openapi.JobStatus) error
 	GetTaskInfo(string, string, string) (openapi.TaskInfo, error)
 	GetTasksInfo(string, string, int32, bool) ([]openapi.TaskInfo, error)
+	GetTasksInfoGeneric(string, string, int32, bool, bool) ([]openapi.TaskInfo, error)
 }
 
 // TaskService is an interface that defines a collection of APIs related to task

--- a/cmd/deployer/app/resource_handler.go
+++ b/cmd/deployer/app/resource_handler.go
@@ -162,7 +162,7 @@ func (r *resourceHandler) addResource(jobId string) {
 	if err != nil {
 		fmt.Printf("Failed to get deploymentConfig for job %s: %v\n", jobId, err)
 	}
-	zap.S().Infof("Got deployment config from apiserver")
+	zap.S().Infof("Got deployment config from apiserver: %v", deploymentConfig)
 
 	// Deploy resources (agents) for the job based on the configuration
 	err = r.deployResources(deploymentConfig)

--- a/pkg/openapi/apiserver/api_computes_service.go
+++ b/pkg/openapi/apiserver/api_computes_service.go
@@ -136,7 +136,7 @@ func (s *ComputesApiService) GetDeploymentConfig(ctx context.Context, computeId 
 		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
-	zap.S().Infof("Successfully got deployment config from controller for jobId %s and computeId %s", jobId, computeId)
+	zap.S().Infof("Successfully got deployment config %v from controller for jobId %s and computeId %s", deploymentConfig, jobId, computeId)
 
 	return openapi.Response(http.StatusOK, deploymentConfig), nil
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -54,6 +54,7 @@ const (
 	DBFieldTaskDirty = "dirty"
 	DBFieldTaskKey   = "key"
 	DBFieldTimestamp = "timestamp"
+	DBFieldComputeId = "computeid"
 
 	// Port numbers
 	ApiServerRestApiPort  = 10100 // REST API port


### PR DESCRIPTION
This pr enables the controller to correctly populate the deployment configuration for tasks to be deployed on resources. The deployer receives back this configuration which it will use to allocate new compute resources.