### PR TITLE
Added checks for dataset registration

### DIFF
--- a/api/dataset_components.partials.yml
+++ b/api/dataset_components.partials.yml
@@ -47,6 +47,8 @@ DatasetInfo:
     # helps launching an ML workload in a cluster or machine associated with the launcher).
     realm:
       type: string
+    computeId:
+      type: string
     # if it is not public, the dataset meta info is filtered when search is done by other users
     isPublic:
       type: boolean
@@ -61,5 +63,6 @@ DatasetInfo:
     description: dataset containing handwritten digits
     url: https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz
     dataFormat: npy
-    realm: "us|west|org1|cluster1"
+    realm: "us/west/org1/cluster1"
+    computeId: "cluster1"
     isPublic: true

--- a/cmd/controller/app/database/db_interfaces.go
+++ b/cmd/controller/app/database/db_interfaces.go
@@ -86,4 +86,6 @@ type TaskService interface {
 // ComputeService is an interface that defines a collection of APIs related to computes
 type ComputeService interface {
 	RegisterCompute(openapi.ComputeSpec) (openapi.ComputeStatus, error)
+	GetComputeIdsByRegion(string) ([]string, error)
+	GetComputeById(string) (openapi.ComputeSpec, error)
 }

--- a/cmd/controller/app/database/mongodb/task.go
+++ b/cmd/controller/app/database/mongodb/task.go
@@ -60,12 +60,14 @@ func (db *MongoService) CreateTasks(tasks []objects.Task, dirty bool) error {
 				util.DBFieldTaskType:  task.Type,
 				"config":              cfgData,
 				"code":                task.ZippedCode,
+				util.DBFieldComputeId: task.ComputeId,
 				util.DBFieldTaskDirty: dirty,
 				util.DBFieldTaskKey:   task.Key,
 				util.DBFieldState:     openapi.READY,
 				util.DBFieldTimestamp: time.Now(),
 			},
 		}
+		zap.S().Debugf("taskID %s is assigned compute %s", task.TaskId, task.ComputeId)
 
 		after := options.After
 		upsert := true

--- a/cmd/controller/app/job/builder.go
+++ b/cmd/controller/app/job/builder.go
@@ -31,7 +31,6 @@ import (
 )
 
 const (
-	realmSep       = "/"
 	defaultGroup   = "default"
 	groupByTypeTag = "tag"
 	taskKeyLen     = 32
@@ -350,7 +349,7 @@ func _walkForGroupByCheck(templates map[string]*taskTemplate, prevTmpl *taskTemp
 		minLen := 0
 		tmpLen := math.MaxInt32
 		for _, val := range channel.GroupBy.Value {
-			length := len(strings.Split(val, realmSep))
+			length := len(strings.Split(val, util.RealmSep))
 			tmpLen = funcMin(tmpLen, length)
 		}
 
@@ -466,6 +465,7 @@ func (tmpl *taskTemplate) buildTasks(prevPeer string, templates map[string]*task
 
 		for i, dataset := range datasets {
 			task := tmpl.Task
+			task.ComputeId = dataset.ComputeId
 			task.Configure(openapi.SYSTEM, util.RandString(taskKeyLen), dataset.Realm, dataset.Url, i)
 			tasks = append(tasks, task)
 		}
@@ -481,7 +481,8 @@ func (tmpl *taskTemplate) buildTasks(prevPeer string, templates map[string]*task
 
 		for i := 0; i < len(channel.GroupBy.Value); i++ {
 			task := tmpl.Task
-			realm := channel.GroupBy.Value[i] + realmSep + util.ProjectName
+			realm := channel.GroupBy.Value[i] + util.RealmSep + util.ProjectName
+			task.ComputeId = util.DefaultRealm
 			task.Configure(openapi.SYSTEM, util.RandString(taskKeyLen), realm, emptyDatasetUrl, i)
 
 			tasks = append(tasks, task)

--- a/cmd/controller/app/job/builder_test.go
+++ b/cmd/controller/app/job/builder_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cisco-open/flame/cmd/controller/config"
 	"github.com/cisco-open/flame/pkg/openapi"
+	"github.com/cisco-open/flame/pkg/util"
 )
 
 var (
@@ -123,7 +124,7 @@ var (
 )
 
 func composeGroup(tokens ...string) string {
-	return strings.Join(tokens, realmSep)
+	return strings.Join(tokens, util.RealmSep)
 }
 
 func TestGetTaskTemplates(t *testing.T) {

--- a/cmd/controller/app/objects/task.go
+++ b/cmd/controller/app/objects/task.go
@@ -26,11 +26,12 @@ import (
 )
 
 type Task struct {
-	JobId  string           `json:"jobid"`
-	TaskId string           `json:"taskid"`
-	Role   string           `json:"role"`
-	Type   openapi.TaskType `json:"type"`
-	Key    string           `json:"key"`
+	JobId     string           `json:"jobid"`
+	TaskId    string           `json:"taskid"`
+	Role      string           `json:"role"`
+	Type      openapi.TaskType `json:"type"`
+	Key       string           `json:"key"`
+	ComputeId string           `json:"computeid"`
 
 	// the following are config and code
 	JobConfig  JobConfig

--- a/fiab/helm-chart/values.yaml
+++ b/fiab/helm-chart/values.yaml
@@ -98,7 +98,7 @@ mlflow:
 
 deployer:
   adminId: "admin-1"
-  region: "us-east"
+  region: "default/us/west"
   computeId: "compute-1"
   apiKey: "apiKey-1"
 

--- a/pkg/openapi/model_dataset_info.go
+++ b/pkg/openapi/model_dataset_info.go
@@ -41,5 +41,7 @@ type DatasetInfo struct {
 
 	Realm string `json:"realm"`
 
+	ComputeId string `json:"computeId,omitempty"`
+
 	IsPublic bool `json:"isPublic,omitempty"`
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -39,22 +39,23 @@ const (
 
 	// Database Fields
 	//TODO append Field to distinguish the fields
-	DBFieldMongoID   = "_id"
-	DBFieldUserId    = "userid"
-	DBFieldId        = "id"
-	DBFieldDesignId  = "designid"
-	DBFieldSchemaId  = "schemaid"
-	DBFieldJobId     = "jobid"
-	DBFieldTaskId    = "taskid"
-	DBFieldState     = "state"
-	DBFieldRole      = "role"
-	DBFieldTaskLog   = "log"
-	DBFieldTaskType  = "type"
-	DBFieldIsPublic  = "ispublic"
-	DBFieldTaskDirty = "dirty"
-	DBFieldTaskKey   = "key"
-	DBFieldTimestamp = "timestamp"
-	DBFieldComputeId = "computeid"
+	DBFieldMongoID       = "_id"
+	DBFieldUserId        = "userid"
+	DBFieldId            = "id"
+	DBFieldDesignId      = "designid"
+	DBFieldSchemaId      = "schemaid"
+	DBFieldJobId         = "jobid"
+	DBFieldTaskId        = "taskid"
+	DBFieldState         = "state"
+	DBFieldRole          = "role"
+	DBFieldTaskLog       = "log"
+	DBFieldTaskType      = "type"
+	DBFieldIsPublic      = "ispublic"
+	DBFieldTaskDirty     = "dirty"
+	DBFieldTaskKey       = "key"
+	DBFieldTimestamp     = "timestamp"
+	DBFieldComputeId     = "computeid"
+	DBFieldComputeRegion = "region"
 
 	// Port numbers
 	ApiServerRestApiPort  = 10100 // REST API port
@@ -82,4 +83,7 @@ const (
 	TaskCodeFile   = "code.zip"
 
 	LogDirPath = "/var/log/" + ProjectName
+
+	DefaultRealm = "default"
+	RealmSep     = "/"
 )


### PR DESCRIPTION
This pr maps the realm in the input dataset json to the registered computes. The realm in the dataset json specifies either region OR computeId. If the dataset is private, the specified region or computeId must be correct. If it is invalid, an error would be thrown and creation of the dataset would fail. In the case of public datasets, if the region or computeId does not match, the defaultRealm is selected which also specifies a default computeId. The dataset realm is used at the time of task creation to assign computeIds and the job tasks get assigned to that compute cluster.