### PR TITLE
Automated deployment notification to computes

### DIFF
--- a/api/job_components.partials.yml
+++ b/api/job_components.partials.yml
@@ -239,6 +239,8 @@ TaskInfo:
       type: string
     state:
       $ref: '#/components/schemas/JobState' # reuse job state
+    computeId:
+      type: string
     log:
       type: string
     timestamp:

--- a/cmd/controller/app/job/default_handler.go
+++ b/cmd/controller/app/job/default_handler.go
@@ -323,8 +323,22 @@ func (h *DefaultHandler) notifyJob(evtType pbNotify.JobEventType) error {
 }
 
 func (h *DefaultHandler) notifyDeploy(evtType pbNotify.DeployEventType) error {
-	// TODO: add computeId field to tasks and remove hard-coding
-	computeIds := []string{"compute-1"}
+	// Get a list of computeIds to notify for deployment
+	// To do this, get all tasks for the jobId, iterate and get computeId
+	computeIdMap := make(map[string]bool)
+
+	for _, taskInfo := range h.tasksInfo {
+		taskCompute := taskInfo.ComputeId
+		computeIdMap[taskCompute] = true
+	}
+
+	computeIds := make([]string, len(computeIdMap))
+	i := 0
+	for compute := range computeIdMap {
+		computeIds[i] = compute
+		i++
+	}
+	zap.S().Infof("In notifyDeploy for tasks, jobId %s, will be notifing computes: %v", h.jobId, computeIds)
 
 	req := &pbNotify.DeployEventRequest{
 		Type:       evtType,

--- a/cmd/notifier/app/eventroute.go
+++ b/cmd/notifier/app/eventroute.go
@@ -97,11 +97,13 @@ func (s *notificationServer) GetDeployEvent(in *pbNotify.DeployInfo, stream pbNo
 
 func (s *notificationServer) getDeployEventChannel(computeId string) chan *pbNotify.DeployEvent {
 	var eventCh chan *pbNotify.DeployEvent
+	zap.S().Infof("Getting deploy event channel for deployer %s", computeId)
 
 	s.mutexDeploy.Lock()
 	if _, ok := s.deployEventQueues[computeId]; !ok {
 		eventCh = make(chan *pbNotify.DeployEvent, eventChannelLen)
 		s.deployEventQueues[computeId] = eventCh
+		zap.S().Infof("Couldn't get existing channel. Created deploy event channel for deployer %s", computeId)
 	} else {
 		eventCh = s.deployEventQueues[computeId]
 	}

--- a/cmd/notifier/app/triggerroute.go
+++ b/cmd/notifier/app/triggerroute.go
@@ -87,6 +87,7 @@ func (s *notificationServer) NotifyDeploy(ctx context.Context, in *pbNotify.Depl
 
 	failedDeployers := make([]string, 0)
 	for _, computeId := range in.ComputeIds {
+		zap.S().Infof("Going to send deploy event to deployer %s", computeId)
 		event := pbNotify.DeployEvent{
 			Type:  in.Type,
 			JobId: in.JobId,
@@ -99,6 +100,7 @@ func (s *notificationServer) NotifyDeploy(ctx context.Context, in *pbNotify.Depl
 			// Do nothing
 		default:
 			failedDeployers = append(failedDeployers, computeId)
+			zap.S().Infof("Failed to send deploy event to deployer %s, updated failedDeployers: %v", computeId, failedDeployers)
 		}
 	}
 

--- a/pkg/openapi/controller/api_computes_service.go
+++ b/pkg/openapi/controller/api_computes_service.go
@@ -116,7 +116,7 @@ func (s *ComputesApiService) GetDeploymentConfig(ctx context.Context, computeId 
 	// Sending empty string as client name in GetTasksInfo_ call => No computeId filter will be
 	// applied as field doesnt exist in the mongodb task collection yet
 	// TODO Add computeId field to the task collection and send computeId into the GetTasksInfo_ call
-	jobTasks, err := s.dbService.GetTasksInfoGeneric("", jobId, 0, true, true)
+	jobTasks, err := s.dbService.GetTasksInfoGeneric(computeId, jobId, 0, true, true)
 	if err != nil {
 		zap.S().Errorf("Error while populating deployment config for jobId %s and computeId %s, err: %v", jobId, computeId, err)
 		return openapi.Response(http.StatusInternalServerError, nil), nil

--- a/pkg/openapi/model_task_info.go
+++ b/pkg/openapi/model_task_info.go
@@ -43,6 +43,8 @@ type TaskInfo struct {
 
 	State JobState `json:"state,omitempty"`
 
+	ComputeId string `json:"computeId,omitempty"`
+
 	Log string `json:"log,omitempty"`
 
 	Timestamp time.Time `json:"timestamp,omitempty"`


### PR DESCRIPTION
A job consists of several tasks that might be deployed across different compute clusters. This pr allows the controller to automatically identify and notify a list of computes for deploying resources for tasks.