### PR TITLE
Added deployer for default compute

### DIFF
--- a/fiab/helm-chart/templates/deployer-compute1-deployment.yaml
+++ b/fiab/helm-chart/templates/deployer-compute1-deployment.yaml
@@ -1,0 +1,53 @@
+# Copyright 2022 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-deployer-compute1
+  namespace: {{ .Release.Namespace }}
+
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-deployer-compute1
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-deployer-compute1
+    spec:
+      containers:
+        - args:
+          - --apiserver
+          - "https://{{ .Values.frontDoorUrl.apiserver }}:443"
+          - --notifier
+          - "{{ .Values.frontDoorUrl.notifier }}:443"
+          - --adminid
+          - {{ .Values.deployerCompute1.adminId }}
+          - --region
+          - {{ .Values.deployerCompute1.region }}
+          - --computeid
+          - {{ .Values.deployerCompute1.computeId }}
+          - --apikey
+          - {{ .Values.deployerCompute1.apiKey }}
+          {{ if .Values.insecure }}
+          - "--insecure"
+          {{ end }}
+          command: ["/usr/bin/deployer"]
+          image: {{ .Values.imageName }}:{{ .Values.imageTag }}
+          imagePullPolicy: IfNotPresent
+          name: {{ .Release.Name }}-deployer-compute1

--- a/fiab/helm-chart/templates/deployer-default-deployment.yaml
+++ b/fiab/helm-chart/templates/deployer-default-deployment.yaml
@@ -17,18 +17,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-deployer
+  name: {{ .Release.Name }}-deployer-default
   namespace: {{ .Release.Namespace }}
 
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-deployer
+      app: {{ .Release.Name }}-deployer-default
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-deployer
+        app: {{ .Release.Name }}-deployer-default
     spec:
       containers:
         - args:
@@ -37,17 +37,17 @@ spec:
           - --notifier
           - "{{ .Values.frontDoorUrl.notifier }}:443"
           - --adminid
-          - {{ .Values.deployer.adminId }}
+          - {{ .Values.deployerDefault.adminId }}
           - --region
-          - {{ .Values.deployer.region }}
+          - {{ .Values.deployerDefault.region }}
           - --computeid
-          - {{ .Values.deployer.computeId }}
+          - {{ .Values.deployerDefault.computeId }}
           - --apikey
-          - {{ .Values.deployer.apiKey }}
+          - {{ .Values.deployerDefault.apiKey }}
           {{ if .Values.insecure }}
           - "--insecure"
           {{ end }}
           command: ["/usr/bin/deployer"]
           image: {{ .Values.imageName }}:{{ .Values.imageTag }}
           imagePullPolicy: IfNotPresent
-          name: {{ .Release.Name }}-deployer
+          name: {{ .Release.Name }}-deployer-default

--- a/fiab/helm-chart/values.yaml
+++ b/fiab/helm-chart/values.yaml
@@ -96,8 +96,14 @@ mlflow:
   s3EndpointUrl: http://minio.flame.test
   servicePort: "5000"
 
-deployer:
+deployerDefault:
   adminId: "admin-1"
+  region: "default/us"
+  computeId: "default"
+  apiKey: "apiKey-default"
+
+deployerCompute1:
+  adminId: "admin-2"
   region: "default/us/west"
   computeId: "compute-1"
   apiKey: "apiKey-1"


### PR DESCRIPTION
This pr adds a default compute deployer besides the existing custom deployer. The default compute is primarily useful for aggregation tasks and/or running tasks on public datasets which were not correctly mapped to a compute region.