### PR TITLE
Duplicating controllers deployment code into deployer

### DIFF
--- a/cmd/controller/app/job/default_handler.go
+++ b/cmd/controller/app/job/default_handler.go
@@ -195,6 +195,9 @@ func (h *DefaultHandler) doHandle(event *JobEvent) {
 }
 
 func (h *DefaultHandler) cleanup() {
+	h.notifyDeploy(pbNotify.DeployEventType_REVOKE_RESOURCE)
+	zap.S().Infof("Invoking notifyDeploy - revoke resource - from cleanup()")
+
 	// 1. decommission compute resources if they are in use
 	if h.dplyr != nil {
 		if err := h.dplyr.Uninstall("job-" + h.jobId); err != nil {

--- a/cmd/deployer/app/deployer/deployer.go
+++ b/cmd/deployer/app/deployer/deployer.go
@@ -1,0 +1,59 @@
+// Copyright 2022 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package deployer
+
+import (
+	"fmt"
+	"sync"
+)
+
+const (
+	AKE    = "ake"    // Microsoft’s Azure Kubernetes Service
+	EKS    = "eks"    // Amazon’s Elastic Kubernetes Service
+	GKE    = "gke"    // Google’s Kubernetes Engine
+	K8S    = "k8s"    // vanilla kubernetes
+	DOCKER = "docker" // docker or docker compose; only for local dev
+)
+
+var (
+	envLock sync.Mutex
+)
+
+type Deployer interface {
+	Initialize(string, string) error
+	Install(string, string) error
+	Uninstall(string) error
+	List() error
+}
+
+func NewDeployer(platform string) (Deployer, error) {
+	// TODO: support other platforms: AKE, EKS, GKE, etc.
+	switch platform {
+	case K8S:
+		return NewK8sDeployer()
+	case DOCKER:
+		return NewDockerDeployer()
+	case AKE:
+		fallthrough
+	case EKS:
+		fallthrough
+	case GKE:
+		fallthrough
+	default:
+		return nil, fmt.Errorf("unknown platform: %s", platform)
+	}
+}

--- a/cmd/deployer/app/deployer/docker.go
+++ b/cmd/deployer/app/deployer/docker.go
@@ -1,0 +1,54 @@
+// Copyright 2022 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package deployer
+
+import (
+	"go.uber.org/zap"
+)
+
+// NOTE: DockerDeployer doesn't support dynamic deployment as docker and
+//
+//	docker-compose are only for local development purpose
+type DockerDeployer struct{}
+
+func NewDockerDeployer() (*DockerDeployer, error) {
+	return &DockerDeployer{}, nil
+}
+
+func (deployer *DockerDeployer) Initialize(_ string, _ string) error {
+	zap.S().Infof("not supported")
+
+	return nil
+}
+
+func (deployer *DockerDeployer) Install(_ string, _ string) error {
+	zap.S().Infof("not supported")
+
+	return nil
+}
+
+func (deployer *DockerDeployer) Uninstall(_ string) error {
+	zap.S().Infof("not supported")
+
+	return nil
+}
+
+func (deployer *DockerDeployer) List() error {
+	zap.S().Infof("not supported")
+
+	return nil
+}

--- a/cmd/deployer/app/deployer/k8s.go
+++ b/cmd/deployer/app/deployer/k8s.go
@@ -1,0 +1,114 @@
+// Copyright 2022 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package deployer
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/cli"
+)
+
+type K8sDeployer struct {
+	clusterName string // Currently not in use
+	namespace   string
+
+	actionConfig action.Configuration
+}
+
+func NewK8sDeployer() (*K8sDeployer, error) {
+	return &K8sDeployer{}, nil
+}
+
+func (deployer *K8sDeployer) getEnvSettings(namespace string) (*cli.EnvSettings, error) {
+	envLock.Lock()
+	defer envLock.Unlock()
+
+	err := os.Setenv("HELM_NAMEPSACE", namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	envSettings := cli.New()
+	err = os.Unsetenv("HELM_NAMEPSACE")
+	if err != nil {
+		return nil, err
+	}
+
+	return envSettings, nil
+}
+
+func (deployer *K8sDeployer) Initialize(clusterName string, namespace string) error {
+	deployer.clusterName = clusterName
+	deployer.namespace = namespace
+
+	settings, err := deployer.getEnvSettings(namespace)
+	if err != nil {
+		return err
+	}
+
+	actionConfig := new(action.Configuration)
+
+	err = actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), zap.S().Debugf)
+	if err != nil {
+		return err
+	}
+
+	deployer.actionConfig = *actionConfig
+
+	return nil
+}
+
+func (deployer *K8sDeployer) Install(releaseName string, chartPath string) error {
+	chart, err := loader.Load(chartPath)
+	if err != nil {
+		return err
+	}
+
+	installObj := action.NewInstall(&deployer.actionConfig)
+	installObj.Namespace = deployer.namespace
+	installObj.ReleaseName = releaseName
+	release, err := installObj.Run(chart, nil)
+	if err != nil {
+		return err
+	}
+
+	zap.S().Infof("Successfully installed release: %s", release.Name)
+
+	return nil
+}
+
+func (deployer *K8sDeployer) Uninstall(releaseName string) error {
+	uninstallObj := action.NewUninstall(&deployer.actionConfig)
+	resp, err := uninstallObj.Run(releaseName)
+	if err != nil {
+		return err
+	}
+
+	zap.S().Infof("Successfully removed %s", resp.Release.Name)
+	return nil
+}
+
+func (deployer *K8sDeployer) List() error {
+	listObj := action.NewList(&deployer.actionConfig)
+	listObj.StateMask ^= action.ListFailed // clear failed releases
+	listObj.Run()
+
+	return nil
+}

--- a/cmd/deployer/app/resource_handler.go
+++ b/cmd/deployer/app/resource_handler.go
@@ -172,9 +172,27 @@ func (r *resourceHandler) addResource(jobId string) {
 	zap.S().Infof("Successfully added resources for compute %s and jobId %s", r.spec.ComputeId, jobId)
 }
 
-func (r *resourceHandler) revokeResource(jobId string) {
+func (r *resourceHandler) revokeResource(jobId string) error {
 	zap.S().Infof("Received revoke resource request for job %s", jobId)
-	// TODO: implement revokeResource method
+
+	// WORK IN PROGRESS: Moved code directly from controller. Contains only core logic which could be used.
+	// However, it needs to be re-written to be used in the standalone deployer.
+
+	// // 1. decommission compute resources if they are in use
+	// if h.dplyr != nil {
+	// 	if err := h.dplyr.Uninstall("job-" + h.jobId); err != nil {
+	// 		zap.S().Warnf("failed to release resources for job %s: %v", h.jobId, err)
+	// 	}
+	// }
+
+	// // 2.delete all the job resource specification files
+	// deploymentChartPath := filepath.Join(deploymentDirPath, h.jobId)
+	// _ = os.RemoveAll(deploymentChartPath)
+
+	// h.tskWatchCancelFn()
+
+	zap.S().Infof("Completed revocation of agent resources")
+	return nil
 }
 
 func (r *resourceHandler) getDeploymentConfig(jobId string) (openapi.DeploymentConfig, error) {
@@ -203,8 +221,88 @@ func (r *resourceHandler) getDeploymentConfig(jobId string) (openapi.DeploymentC
 func (r *resourceHandler) deployResources(deploymentConfig openapi.DeploymentConfig) error {
 	zap.S().Infof("Beginning deployment of agents")
 
-	// iterate over agent kvs and invoke install for each
-	// Create more functions and move code from /cmd/controller/deployer/k8s.go
+	// WORK IN PROGRESS: Moved code directly from controller. Contains only core logic which could be used.
+	// However, it needs to be re-written to be used in the standalone deployer.
+
+	// deploymentChartPath := filepath.Join(deploymentDirPath, h.jobId)
+	// targetTemplateDirPath := filepath.Join(deploymentChartPath, deploymentTemplateDir)
+	// if err := os.MkdirAll(targetTemplateDirPath, util.FilePerm0644); err != nil {
+	// 	errMsg := fmt.Sprintf("failed to create a deployment template folder: %v", err)
+	// 	zap.S().Debugf(errMsg)
+
+	// 	return fmt.Errorf(errMsg)
+	// }
+
+	// // Copy helm chart files to destination folder
+	// for _, chartFile := range helmChartFiles {
+	// 	srcFilePath := filepath.Join(jobTemplateDirPath, chartFile)
+	// 	dstFilePath := filepath.Join(deploymentChartPath, chartFile)
+	// 	err := util.CopyFile(srcFilePath, dstFilePath)
+	// 	if err != nil {
+	// 		errMsg := fmt.Sprintf("failed to copy a deployment chart file %s: %v", chartFile, err)
+	// 		zap.S().Debugf(errMsg)
+
+	// 		return fmt.Errorf(errMsg)
+	// 	}
+	// }
+
+	// for _, taskInfo := range h.tasksInfo {
+	// 	if taskInfo.Type == openapi.USER {
+	// 		// don't attempt to provision compute resource for user-driven task
+	// 		continue
+	// 	}
+
+	// 	context := map[string]string{
+	// 		"imageLoc": h.jobParams.Image,
+	// 		"taskId":   taskInfo.TaskId,
+	// 		"taskKey":  taskInfo.Key,
+	// 	}
+	// 	rendered, err := mustache.RenderFile(jobTemplatePath, &context)
+	// 	if err != nil {
+	// 		errMsg := fmt.Sprintf("failed to render a template for task %s: %v", taskInfo.TaskId, err)
+	// 		zap.S().Debugf(errMsg)
+
+	// 		return fmt.Errorf(errMsg)
+	// 	}
+
+	// 	deploymentFileName := fmt.Sprintf("%s-%s.yaml", jobDeploymentFilePrefix, taskInfo.TaskId)
+	// 	deploymentFilePath := filepath.Join(targetTemplateDirPath, deploymentFileName)
+	// 	err = ioutil.WriteFile(deploymentFilePath, []byte(rendered), util.FilePerm0644)
+	// 	if err != nil {
+	// 		errMsg := fmt.Sprintf("failed to write a job rosource spec %s: %v", taskInfo.TaskId, err)
+	// 		zap.S().Debugf(errMsg)
+
+	// 		return fmt.Errorf(errMsg)
+	// 	}
+	// }
+
+	// // TODO: when multiple clusters are supported,
+	// //       set platform dynamically based on the target cluster type
+	// dplyr, err := deployer.NewDeployer(h.platform)
+	// if err != nil {
+	// 	errMsg := fmt.Sprintf("failed to obtain a job deployer: %v", err)
+	// 	zap.S().Debugf(errMsg)
+
+	// 	return fmt.Errorf(errMsg)
+	// }
+
+	// err = dplyr.Initialize("", h.namespace)
+	// if err != nil {
+	// 	errMsg := fmt.Sprintf("failed to initialize a job deployer: %v", err)
+	// 	zap.S().Debugf(errMsg)
+
+	// 	return fmt.Errorf(errMsg)
+	// }
+
+	// err = dplyr.Install("job-"+h.jobId, deploymentChartPath)
+	// if err != nil {
+	// 	errMsg := fmt.Sprintf("failed to deploy tasks: %v", err)
+	// 	zap.S().Debugf(errMsg)
+
+	// 	return fmt.Errorf(errMsg)
+	// }
+
+	// h.dplyr = dplyr
 
 	zap.S().Infof("Completed deployment of agents")
 	return nil

--- a/fiab/helm-chart/templates/deployer-compute1-deployment.yaml
+++ b/fiab/helm-chart/templates/deployer-compute1-deployment.yaml
@@ -51,3 +51,11 @@ spec:
           image: {{ .Values.imageName }}:{{ .Values.imageTag }}
           imagePullPolicy: IfNotPresent
           name: {{ .Release.Name }}-deployer-compute1
+          volumeMounts:
+            - mountPath: /flame/template
+              name: job-template-volume
+      
+      volumes:
+        - name: job-template-volume
+          configMap:
+            name: {{ .Release.Name }}-deployer-job-configmap

--- a/fiab/helm-chart/templates/deployer-default-deployment.yaml
+++ b/fiab/helm-chart/templates/deployer-default-deployment.yaml
@@ -51,3 +51,11 @@ spec:
           image: {{ .Values.imageName }}:{{ .Values.imageTag }}
           imagePullPolicy: IfNotPresent
           name: {{ .Release.Name }}-deployer-default
+          volumeMounts:
+            - mountPath: /flame/template
+              name: job-template-volume
+      
+      volumes:
+        - name: job-template-volume
+          configMap:
+            name: {{ .Release.Name }}-deployer-job-configmap

--- a/fiab/helm-chart/templates/deployer-job-configmap.yaml
+++ b/fiab/helm-chart/templates/deployer-job-configmap.yaml
@@ -1,0 +1,49 @@
+# Copyright 2022 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-deployer-job-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  Chart.yaml: |
+    ---
+    apiVersion: v1
+    appVersion: "1.0"
+    description: a helm chart for flame job
+    name: flame-job
+    version: 1.0
+
+  values.yaml: |
+    ---
+    servicePort:
+      agent: {{ .Values.servicePort.agent }}
+
+    endpoint:
+      apiserver: https://{{ .Values.frontDoorUrl.apiserver }}:443
+      notifier: {{ .Values.frontDoorUrl.notifier }}:443
+
+    s3EndpointUrl: {{ .Values.mlflow.s3EndpointUrl }}
+    accessKeyId: {{ (index .Values.minio.users 0).accessKey }}
+    secretAccessKey: {{ (index .Values.minio.users 0).secretKey }}
+
+    # enable this in case a selfsigned cert is in use (for test only)
+    # this holds true in fiab setting
+    insecure: true
+
+  {{- (.Files.Glob "job/job-agent.yaml.mustache").AsConfig | nindent 2}}


### PR DESCRIPTION
This pr is a step towards implementing the core deployment logic into the deployer. We duplicate the relevant code and logic from the controller's deployer and put it as placeholder in the standalone deployer's code. At a later stage, only logic within the deployer will remain and all deployment related code from the controller will be removed.