### PR TITLE
Added servAcc and roleBinding for deployer

### DIFF
--- a/fiab/helm-chart/templates/deployer-compute1-deployment.yaml
+++ b/fiab/helm-chart/templates/deployer-compute1-deployment.yaml
@@ -55,6 +55,7 @@ spec:
             - mountPath: /flame/template
               name: job-template-volume
       
+      serviceAccountName: deployer
       volumes:
         - name: job-template-volume
           configMap:

--- a/fiab/helm-chart/templates/deployer-default-deployment.yaml
+++ b/fiab/helm-chart/templates/deployer-default-deployment.yaml
@@ -55,6 +55,7 @@ spec:
             - mountPath: /flame/template
               name: job-template-volume
       
+      serviceAccountName: deployer
       volumes:
         - name: job-template-volume
           configMap:

--- a/fiab/helm-chart/templates/deployer-role-and-rolebinding.yaml
+++ b/fiab/helm-chart/templates/deployer-role-and-rolebinding.yaml
@@ -1,0 +1,41 @@
+# Copyright 2022 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# source: https://docs.armory.io/docs/armory-admin/manual-service-account/
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: deployer-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: deployer-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deployer-role
+subjects:
+- namespace: {{ .Release.Namespace }}
+  kind: ServiceAccount
+  name: deployer

--- a/fiab/helm-chart/templates/deployer-service-account.yaml
+++ b/fiab/helm-chart/templates/deployer-service-account.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deployer
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This pr adds service account, roles and role bindings for deployer. These privileges will be used by the deployer to create and delete pods for tasks.