### PR TITLE
Removed deprecated io-ioutil API calls

### DIFF
--- a/cmd/controller/app/job/builder.go
+++ b/cmd/controller/app/job/builder.go
@@ -19,8 +19,8 @@ package job
 import (
 	"container/list"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"strings"
 
 	"github.com/cisco-open/flame/cmd/controller/app/database"
@@ -95,7 +95,7 @@ func (b *JobBuilder) setup() error {
 		return err
 	}
 
-	f, err := ioutil.TempFile("", util.ProjectName)
+	f, err := os.CreateTemp("", util.ProjectName)
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %v", err)
 	}

--- a/cmd/deployer/app/resource_handler.go
+++ b/cmd/deployer/app/resource_handler.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -287,7 +286,7 @@ func (r *resourceHandler) deployResources(deploymentConfig openapi.DeploymentCon
 
 		deploymentFileName := fmt.Sprintf("%s-%s.yaml", jobDeploymentFilePrefix, taskId)
 		deploymentFilePath := filepath.Join(targetTemplateDirPath, deploymentFileName)
-		err = ioutil.WriteFile(deploymentFilePath, []byte(rendered), util.FilePerm0644)
+		err = os.WriteFile(deploymentFilePath, []byte(rendered), util.FilePerm0644)
 		if err != nil {
 			errMsg := fmt.Sprintf("failed to write a job rosource spec %s: %v", taskId, err)
 			zap.S().Debugf(errMsg)

--- a/cmd/flamectl/resources/code/code.go
+++ b/cmd/flamectl/resources/code/code.go
@@ -19,7 +19,6 @@ package code
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -94,7 +93,7 @@ func Get(params Params) error {
 	}
 
 	fileName := params.DesignId + "_ver-" + params.CodeVer + ".zip"
-	err = ioutil.WriteFile(fileName, respBody, util.FilePerm0644)
+	err = os.WriteFile(fileName, respBody, util.FilePerm0644)
 	if err != nil {
 		fmt.Printf("Failed to save %s: %v\n", fileName, err)
 		return nil

--- a/cmd/flamectl/resources/dataset/dataset.go
+++ b/cmd/flamectl/resources/dataset/dataset.go
@@ -19,7 +19,6 @@ package dataset
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -38,7 +37,7 @@ type Params struct {
 }
 
 func Create(params Params) error {
-	data, err := ioutil.ReadFile(params.DatasetFile)
+	data, err := os.ReadFile(params.DatasetFile)
 	if err != nil {
 		fmt.Printf("Failed to read file %s: %v\n", params.DatasetFile, err)
 		return nil

--- a/cmd/flamectl/resources/job/job.go
+++ b/cmd/flamectl/resources/job/job.go
@@ -19,7 +19,6 @@ package job
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/olekukonko/tablewriter"
@@ -39,7 +38,7 @@ type Params struct {
 }
 
 func Create(params Params) error {
-	data, err := ioutil.ReadFile(params.JobFile)
+	data, err := os.ReadFile(params.JobFile)
 	if err != nil {
 		fmt.Printf("Failed to read file %s: %v\n", params.JobFile, err)
 		return nil
@@ -189,7 +188,7 @@ func GetStatus(params Params) error {
 }
 
 func Update(params Params) error {
-	data, err := ioutil.ReadFile(params.JobFile)
+	data, err := os.ReadFile(params.JobFile)
 	if err != nil {
 		fmt.Printf("Failed to read file %s: %v\n", params.JobFile, err)
 		return nil

--- a/cmd/flamectl/resources/schema/schema.go
+++ b/cmd/flamectl/resources/schema/schema.go
@@ -19,7 +19,7 @@ package schema
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/cisco-open/flame/cmd/flamectl/resources"
 	"github.com/cisco-open/flame/pkg/openapi"
@@ -37,7 +37,7 @@ type Params struct {
 
 func Create(params Params) error {
 	// read schema via conf file
-	jsonData, err := ioutil.ReadFile(params.SchemaPath)
+	jsonData, err := os.ReadFile(params.SchemaPath)
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func GetMany(params Params) error {
 
 func Update(params Params) error {
 	// read schema via conf file
-	jsonData, err := ioutil.ReadFile(params.SchemaPath)
+	jsonData, err := os.ReadFile(params.SchemaPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/flamelet/app/taskhandler.go
+++ b/cmd/flamelet/app/taskhandler.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -232,7 +231,7 @@ func (t *taskHandler) getTask() ([]string, error) {
 	filePaths := make([]string, 0)
 	for fileName, data := range taskMap {
 		filePath := filepath.Join("/tmp", fileName)
-		err = ioutil.WriteFile(filePath, data, util.FilePerm0755)
+		err = os.WriteFile(filePath, data, util.FilePerm0755)
 		if err != nil {
 			zap.S().Warnf("Failed to save %s: %v\n", fileName, err)
 			return nil, err
@@ -296,7 +295,7 @@ func (t *taskHandler) prepareTask(filePaths []string) error {
 
 func (t *taskHandler) prepareConfig(configFilePath string) error {
 	// copy config file to work directory
-	input, err := ioutil.ReadFile(configFilePath)
+	input, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to open config file %s: %v", configFilePath, err)
 	}
@@ -318,7 +317,7 @@ func (t *taskHandler) prepareConfig(configFilePath string) error {
 	}
 
 	dstFilePath := filepath.Join(workDir, util.TaskConfigFile)
-	err = ioutil.WriteFile(dstFilePath, input, util.FilePerm0644)
+	err = os.WriteFile(dstFilePath, input, util.FilePerm0644)
 	if err != nil {
 		return fmt.Errorf("failed to copy config file: %v", err)
 	}
@@ -336,7 +335,7 @@ func (t *taskHandler) prepareCode(fileDataList []util.FileData) error {
 		}
 
 		filePath := filepath.Join(dirPath, fileData.BaseName)
-		err = ioutil.WriteFile(filePath, []byte(fileData.Data), util.FilePerm0644)
+		err = os.WriteFile(filePath, []byte(fileData.Data), util.FilePerm0644)
 		if err != nil {
 			return fmt.Errorf("failed to unzip file %s: %v", filePath, err)
 		}

--- a/pkg/openapi/routers.go
+++ b/pkg/openapi/routers.go
@@ -29,7 +29,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -128,7 +127,7 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 
 	defer formFile.Close()
 
-	fileBytes, err := ioutil.ReadAll(formFile)
+	fileBytes, err := io.ReadAll(formFile)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +137,7 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 	//                   in tempfile generation, thus causing
 	//                   "pattern contains path separator" error
 	// file, err := ioutil.TempFile("", fileHeader.Filename)
-	file, err := ioutil.TempFile("", "flame")
+	file, err := os.CreateTemp("", "flame")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -171,7 +170,7 @@ func HTTPPost(url string, msg interface{}, contentType string) (int, []byte, err
 	defer resp.Body.Close()
 
 	//Read the response body
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if ErrorNilCheck(GetFunctionName(HTTPPost), err) != nil {
 		return -1, nil, err
 	}
@@ -202,7 +201,7 @@ func HTTPPut(url string, msg interface{}, contentType string) (int, []byte, erro
 	defer resp.Body.Close()
 
 	//Read the response body
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if ErrorNilCheck(GetFunctionName(HTTPPut), err) != nil {
 		return -1, nil, err
 	}
@@ -232,7 +231,7 @@ func HTTPDelete(url string, msg interface{}, contentType string) (int, []byte, e
 	defer resp.Body.Close()
 
 	//Read the response body
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if ErrorNilCheck(GetFunctionName(HTTPDelete), err) != nil {
 		return -1, nil, err
 	}
@@ -248,7 +247,7 @@ func HTTPGet(url string) (int, []byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if ErrorNilCheck(GetFunctionName(HTTPGet), err) != nil {
 		return -1, nil, err
 	}
@@ -274,7 +273,7 @@ func HTTPGetMultipart(url string) (int, map[string][]byte, error) {
 	result := make(map[string][]byte)
 	mr := multipart.NewReader(resp.Body, params["boundary"])
 	for part, err := mr.NextPart(); err == nil; part, err = mr.NextPart() {
-		data, err := ioutil.ReadAll(part)
+		data, err := io.ReadAll(part)
 		if err != nil {
 			return -1, nil, err
 		}

--- a/pkg/util/zip.go
+++ b/pkg/util/zip.go
@@ -20,7 +20,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +52,7 @@ func UnzipFile(file *os.File) ([]FileData, error) {
 			continue
 		}
 
-		data, err := ioutil.ReadAll(rc)
+		data, err := io.ReadAll(rc)
 		if err != nil {
 			rc.Close()
 			return nil, err


### PR DESCRIPTION
The golang linter complained that io-ioutil is deprecated. Thus the function calls were replaced with relevant io and os package APIs.