### PR TITLE
Updated spec for deploymentConfig

### DIFF
--- a/api/computes_components.partials.yml
+++ b/api/computes_components.partials.yml
@@ -77,9 +77,7 @@ DeploymentConfig:
     imageLoc:
       type: string
     agentKVs:
-      type: array
-      items:
-        $ref: '#/components/schemas/AgentKV'
+      $ref: '#/components/schemas/AgentKVs'
   required:
     - jobId
     - imageLoc
@@ -88,7 +86,7 @@ DeploymentConfig:
 ########################################
 # Config for agents in the deployment
 ########################################
-AgentKV:
+AgentKVs:
   description:  Config for agents in the deployment
   type: object
   additionalProperties:

--- a/cmd/deployer/app/resource_handler.go
+++ b/cmd/deployer/app/resource_handler.go
@@ -260,17 +260,8 @@ func (r *resourceHandler) deployResources(deploymentConfig openapi.DeploymentCon
 		}
 	}
 
-	for _, agentKV := range deploymentConfig.AgentKVs {
-		// the agentKV is a map but with just one key (taskId) and one value (taskKey)
-		// TODO fix the api spec to have a map with multiple key:value pairs
-		taskIds := make([]string, len(agentKV))
-		i := 0
-		for k := range agentKV {
-			taskIds[i] = k
-			i++
-		}
-		taskId := taskIds[0]
-		taskKey := agentKV[taskIds[0]]
+	for taskId := range deploymentConfig.AgentKVs {
+		taskKey := deploymentConfig.AgentKVs[taskId]
 
 		context := map[string]string{
 			"imageLoc": deploymentConfig.ImageLoc,

--- a/pkg/openapi/controller/api_computes_service.go
+++ b/pkg/openapi/controller/api_computes_service.go
@@ -126,11 +126,9 @@ func (s *ComputesApiService) GetDeploymentConfig(ctx context.Context, computeId 
 	deploymentConfig.JobId = jobId
 	deploymentConfig.ImageLoc = imageLoc
 
-	agentKVs := []map[string]string{}
+	agentKVs := map[string]string{}
 	for _, task := range jobTasks {
-		agent := make(map[string]string)
-		agent[task.TaskId] = task.Key
-		agentKVs = append(agentKVs, agent)
+		agentKVs[task.TaskId] = task.Key
 	}
 	deploymentConfig.AgentKVs = agentKVs
 

--- a/pkg/openapi/model_deployment_config.go
+++ b/pkg/openapi/model_deployment_config.go
@@ -31,7 +31,8 @@ type DeploymentConfig struct {
 
 	ImageLoc string `json:"imageLoc"`
 
-	AgentKVs []map[string]string `json:"agentKVs"`
+	// Config for agents in the deployment
+	AgentKVs map[string]string `json:"agentKVs"`
 }
 
 // AssertDeploymentConfigRequired checks if the required fields are not zero-ed


### PR DESCRIPTION
This pr updates the agentKV field of deployementConfig spec to a simple map instead of a list of maps.