### PR TITLE
event driven approach

### DIFF
--- a/lib/python/flame/backend/chunk_store.py
+++ b/lib/python/flame/backend/chunk_store.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-
+"""ChunkStore."""
 
 import logging
+from threading import Thread
 from typing import Tuple, Union
 
+from ..common.constants import EMPTY_PAYLOAD
+from ..common.util import run_async
 from ..proto import backend_msg_pb2 as msg_pb2
 
 DEFAULT_CHUNK_SIZE = 1048576  # 1MB
@@ -26,10 +29,19 @@ logger = logging.getLogger(__name__)
 
 
 class ChunkStore(object):
-    def __init__(self):
+    """ChunkStore class."""
+
+    def __init__(self, loop=None, channel=None):
+        """Initialize an instance."""
+        self._loop = loop
+        self._channel = channel
+
         # for fragment
         self.pidx = 0
         self.cidx = DEFAULT_CHUNK_SIZE
+
+        # for assemble
+        self.recv_buf = list()
 
         # for both fragment and assemble
         self.data = b''
@@ -37,6 +49,8 @@ class ChunkStore(object):
         self.eom = False
 
     def set_data(self, data: bytes) -> None:
+        """Set data in chunk store."""
+        logger.debug(f"setting data of size {len(data)}")
         self.data = data
 
         # reset variables since new data is set
@@ -45,8 +59,10 @@ class ChunkStore(object):
 
     def get_chunk(self) -> Tuple[Union[bytes, None], int, bool]:
         """
-        get_chunk() returns None as the first part of the triplet
-        if its internal index is pointing beyond the end of message.
+        Return a chunk of data.
+
+        The method returns None as the first part of the triplet
+        if its internal index is pointing beyond the end of data.
         Otherwise, it returns a chunk every time it is called.
         """
         data_len = len(self.data)
@@ -67,16 +83,54 @@ class ChunkStore(object):
         self.pidx = self.cidx
         self.cidx += DEFAULT_CHUNK_SIZE
 
+        logger.debug(f"chunk {seqno}: {len(data)}")
         return data, seqno, eom
 
     def assemble(self, msg: msg_pb2.Data) -> bool:
+        """Assemble message.
+
+        This method pushes message payload into a receive buffer.
+        If eom (end of message) is set, bytes in the array are joined.
+        Then, the assembled data will be put into a receive queue.
+
+        The join operation can be exepnsive if the data size is large.
+        We run the join operation in a separate thread in order to unblock
+        asyncio tasks as quickly as possible.
+        """
         # out of order delivery
         if self.seqno + 1 != msg.seqno:
             logger.warning(f'out-of-order seqno from {msg.end_id}')
             return False
 
-        self.data += msg.payload
+        logger.debug(f"chunk {msg.seqno}: {len(msg.payload)}")
+        # add payload to a recv buf
+        self.recv_buf.append(msg.payload)
         self.seqno = msg.seqno
         self.eom = msg.eom
 
+        if self.eom:
+            # we assemble payloads in the recv buf array
+            # only if eom is set to True.
+            # In this way, we only pay byte concatenation cost once
+            _thread = Thread(target=self._assemble,
+                             args=(msg.end_id, ),
+                             daemon=True)
+            _thread.start()
+
         return True
+
+    def _assemble(self, end_id: str) -> None:
+        # This code must be executed in a separate thread
+        self.data = EMPTY_PAYLOAD.join(self.recv_buf)
+
+        async def inner():
+            logger.debug(f'fully assembled data size = {len(self.data)}')
+
+            rxq = self._channel.get_rxq(end_id)
+            if rxq is None:
+                logger.debug(f"rxq not found for {end_id}")
+                return
+
+            await rxq.put(self.data)
+
+        _, status = run_async(inner(), self._loop)

--- a/lib/python/flame/common/constants.py
+++ b/lib/python/flame/common/constants.py
@@ -27,6 +27,8 @@ UNIX_SOCKET_PATH = '/tmp/local_registry.socket'
 # default data folder
 DATA_FOLDER_PATH = '/flame/data'
 
+EMPTY_PAYLOAD = b''
+
 
 class BackendEvent(Enum):
     """Enum class for BackendEvent."""

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='flame',
-    version='0.0.10',
+    version='0.0.11',
     author='Flame Maintainers',
     author_email='flame-github-owners@cisco.com',
     include_package_data=True,
@@ -32,6 +32,7 @@ setup(
     " to run ML workloads in the flame system",
     long_description=open('README.md').read(),
     install_requires=[
+        'aiostream',
         'boto3',
         'cloudpickle',
         'diskcache',


### PR DESCRIPTION
The flame library presents some inefficiency.

1) In order to check if there is at least one peer in a channel, it busy-waits by calling empty() function and sleep one second.

2) head-of-line blocking problem: to recv data from peers of a channel, the implementation gets the list of peers, loops through each of peers and calls recv(). If the first peer is a straggler, it causes a head-of-line blocking problem.

3) When model size increases, it takes a while to merge transmitted messages (it is byte array concatenation operation). This process takes place in a coroutine; and it isn't suspended until it is finished. This delays a heart beat transmission as the heart beat function is also a coroutine. The delayed heart beat triggers a timeout at the other side of grpc channel, which breaks a training job.

The first two issues are addressed in an event-driven manner. The third problem is addressed by using threading. The byte array concatenation takes place in a separate thread. So, the asyncio coroutine of handling message will release cpu resource quickly. Therefore, the heart beat transmission function works in a timely manner.

Also, graceful termination is enforced by ensuring data transfer is complete.