### PR TITLE
Add mongo document deletion for delete schema

### DIFF
--- a/cmd/controller/app/database/db_interfaces.go
+++ b/cmd/controller/app/database/db_interfaces.go
@@ -50,6 +50,7 @@ type DesignService interface {
 	GetDesignSchema(userId string, designId string, version string) (openapi.DesignSchema, error)
 	GetDesignSchemas(userId string, designId string) ([]openapi.DesignSchema, error)
 	UpdateDesignSchema(userId string, designId string, version string, info openapi.DesignSchema) error
+	DeleteDesignSchema(userId string, designId string, version string) error
 
 	CreateDesignCode(userId string, designId string, fileName string, fileVer string, fileData *os.File) error
 	GetDesignCode(userId string, designId string, version string) ([]byte, error)

--- a/cmd/controller/app/database/mongodb/schema.go
+++ b/cmd/controller/app/database/mongodb/schema.go
@@ -115,3 +115,21 @@ func (db *MongoService) UpdateDesignSchema(userId string, designId string, versi
 
 	return nil
 }
+
+// DeleteDesignSchema delete design schema for the given version and design Id
+func (db *MongoService) DeleteDesignSchema(userId string, designId string, version string) error {
+	zap.S().Debugf("delete design schema : %v, %v,%v", userId, designId, version)
+
+	updateRes, err := db.designCollection.UpdateOne(context.TODO(),
+		bson.M{util.DBFieldUserId: userId, util.DBFieldId: designId},
+		bson.M{"$pull": bson.M{util.DBFieldSchemas: bson.M{"version": version}}})
+	if err != nil {
+		return fmt.Errorf("failed to delete design schema deleted error: %v", err)
+	}
+	if updateRes.ModifiedCount == 0 {
+		return fmt.Errorf("failed to delete design schema, schema version %s not found. deleted schema count: %#v",
+			version, updateRes)
+	}
+	zap.S().Debugf("successfully deleted design schema: %#v", updateRes)
+	return nil
+}

--- a/cmd/controller/app/database/mongodb/schema_test.go
+++ b/cmd/controller/app/database/mongodb/schema_test.go
@@ -1,0 +1,32 @@
+package mongodb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	"testing"
+)
+
+func TestMongoService_DeleteDesignSchema(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	defer mt.Close()
+	mt.Run("success", func(mt *mtest.T) {
+		db := &MongoService{
+			designCollection: mt.Coll,
+		}
+		mt.AddMockResponses(bson.D{{"ok", 1}, {"acknowledged", true},
+			{"n", 1}, {"nModified", 1}})
+		err := db.DeleteDesignSchema("userid", "designid", "version")
+		assert.Nil(t, err)
+	})
+
+	mt.Run("no document deleted", func(mt *mtest.T) {
+		db := &MongoService{
+			designCollection: mt.Coll,
+		}
+		mt.AddMockResponses(bson.D{{"ok", 1}, {"acknowledged", true},
+			{"n", 0}, {"nModified", 0}})
+		err := db.DeleteDesignSchema("userid", "designid", "version")
+		assert.NotNil(t, err)
+	})
+}

--- a/cmd/flamectl/cmd/delete_schema.go
+++ b/cmd/flamectl/cmd/delete_schema.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cisco-open/flame/cmd/flamectl/resources/schema"
+)
+
+var removeSchemaCmd = &cobra.Command{
+	Use:   "schema <version> --design <design id>",
+	Short: "Remove a schema with specific version from a design",
+	Long:  "This command removes a schema with specific version from a design",
+	Args:  cobra.RangeArgs(1, 1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		checkInsecure(cmd)
+
+		schemaVersion := args[0]
+
+		flags := cmd.Flags()
+
+		designId, err := flags.GetString("design")
+		if err != nil {
+			return err
+		}
+
+		params := schema.Params{}
+		params.Endpoint = config.ApiServer.Endpoint
+		params.User = config.User
+		params.DesignId = designId
+		params.Version = schemaVersion
+
+		return schema.Remove(params)
+	},
+}
+
+func init() {
+	removeSchemaCmd.PersistentFlags().StringP("design", "d", "", "Design ID")
+	removeSchemaCmd.MarkPersistentFlagRequired("design")
+	removeCmd.AddCommand(removeSchemaCmd)
+}

--- a/cmd/flamectl/resources/code/code.go
+++ b/cmd/flamectl/resources/code/code.go
@@ -128,7 +128,7 @@ func Remove(params Params) error {
 		return nil
 	}
 
-	fmt.Printf("Deleted %s successfully\n", respBody)
+	fmt.Println("Deleted code successfully")
 
 	return nil
 }

--- a/cmd/flamectl/resources/schema/schema.go
+++ b/cmd/flamectl/resources/schema/schema.go
@@ -158,3 +158,24 @@ func Update(params Params) error {
 
 	return nil
 }
+
+func Remove(params Params) error {
+	// construct URL
+	uriMap := map[string]string{
+		"user":     params.User,
+		"designId": params.DesignId,
+		"version":  params.Version,
+	}
+	url := restapi.CreateURL(params.Endpoint, restapi.DeleteDesignSchemaEndPoint, uriMap)
+
+	statusCode, responseBody, err := restapi.HTTPDelete(url, nil, "")
+	if err != nil || restapi.CheckStatusCode(statusCode) != nil {
+		fmt.Printf("Failed to delete schema of version %s - statusCode: %d, error: %v, responseBody: %v\n",
+			params.Version, statusCode, err, string(responseBody))
+		return nil
+	}
+
+	fmt.Println("Deleted schema successfully")
+
+	return nil
+}

--- a/pkg/openapi/apiserver/api_design_schemas_service.go
+++ b/pkg/openapi/apiserver/api_design_schemas_service.go
@@ -27,7 +27,6 @@ package apiserver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -171,21 +170,25 @@ func (s *DesignSchemasApiService) UpdateDesignSchema(ctx context.Context, user s
 
 func (s *DesignSchemasApiService) DeleteDesignSchema(ctx context.Context, user string, designId string,
 	version string) (openapi.ImplResponse, error) {
-	// TODO - update DeleteDesignCode with the required logic for this service method.
-	// Add api_design_codes_service.go to the .openapi-generator-ignore
-	// to avoid overwriting this service implementation when updating open api generation.
+	//create controller request
+	uriMap := map[string]string{
+		"user":     user,
+		"designId": designId,
+		"version":  version,
+	}
+	url := restapi.CreateURL(HostEndpoint, restapi.DeleteDesignSchemaEndPoint, uriMap)
 
-	//TODO: Uncomment the next line to return response Response(200, {}) or use other options such as http.Ok ...
-	//return openapi.Response(200, nil),nil
+	// send Delete request
+	code, respBody, err := restapi.HTTPDelete(url, "", "application/json")
 
-	//TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	//return openapi.Response(404, nil),nil
+	// response to the user
+	if err != nil {
+		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("delete design schema request failed:%v", err)
+	}
 
-	//TODO: Uncomment the next line to return response Response(401, {}) or use other options such as http.Ok ...
-	//return openapi.Response(401, nil),nil
+	if err = restapi.CheckStatusCode(code); err != nil {
+		return openapi.Response(code, nil), err
+	}
 
-	//TODO: Uncomment the next line to return response Response(0, Error{}) or use other options such as http.Ok ...
-	//return openapi.Response(0, Error{}), nil
-
-	return openapi.Response(http.StatusNotImplemented, nil), errors.New("DeleteDesignCode method not implemented")
+	return openapi.Response(http.StatusOK, respBody), nil
 }

--- a/pkg/openapi/controller/api_design_codes_service.go
+++ b/pkg/openapi/controller/api_design_codes_service.go
@@ -75,7 +75,7 @@ func (s *DesignCodesApiService) DeleteDesignCode(ctx context.Context, user strin
 
 	err := s.dbService.DeleteDesignCode(user, designId, version)
 	if err != nil {
-		return openapi.Response(http.StatusInternalServerError, fmt.Errorf("failed to delete design code: %v", err)),
+		return openapi.Response(http.StatusInternalServerError, nil),
 			fmt.Errorf("failed to delete design code: %v", err)
 	}
 	return openapi.Response(http.StatusOK, nil), nil

--- a/pkg/openapi/controller/api_design_schemas_service.go
+++ b/pkg/openapi/controller/api_design_schemas_service.go
@@ -27,9 +27,10 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
+
+	"go.uber.org/zap"
 
 	"github.com/cisco-open/flame/cmd/controller/app/database"
 	"github.com/cisco-open/flame/pkg/openapi"
@@ -92,21 +93,11 @@ func (s *DesignSchemasApiService) UpdateDesignSchema(ctx context.Context, user s
 
 func (s *DesignSchemasApiService) DeleteDesignSchema(ctx context.Context, user string, designId string,
 	version string) (openapi.ImplResponse, error) {
-	// TODO - update DeleteDesignCode with the required logic for this service method.
-	// Add api_design_codes_service.go to the .openapi-generator-ignore
-	// to avoid overwriting this service implementation when updating open api generation.
+	zap.S().Debugf("Received DeleteDesignSchema Delete request: %s | %s | %s", user, designId, version)
 
-	//TODO: Uncomment the next line to return response Response(200, {}) or use other options such as http.Ok ...
-	//return openapi.Response(200, nil),nil
-
-	//TODO: Uncomment the next line to return response Response(404, {}) or use other options such as http.Ok ...
-	//return openapi.Response(404, nil),nil
-
-	//TODO: Uncomment the next line to return response Response(401, {}) or use other options such as http.Ok ...
-	//return openapi.Response(401, nil),nil
-
-	//TODO: Uncomment the next line to return response Response(0, Error{}) or use other options such as http.Ok ...
-	//return openapi.Response(0, Error{}), nil
-
-	return openapi.Response(http.StatusNotImplemented, nil), errors.New("DeleteDesignCode method not implemented")
+	err := s.dbService.DeleteDesignSchema(user, designId, version)
+	if err != nil {
+		return openapi.Response(http.StatusInternalServerError, nil), fmt.Errorf("failed to delete design schema: %v", err)
+	}
+	return openapi.Response(http.StatusOK, nil), nil
 }

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -49,6 +49,7 @@ const (
 	GetDesignSchemaEndPoint    = "GET_DESIGN_SCHEMA"
 	GetDesignSchemasEndPoint   = "GET_DESIGN_SCHEMAS"
 	UpdateDesignSchemaEndPoint = "UPDATE_DESIGN_SCHEMA"
+	DeleteDesignSchemaEndPoint = "DELETE_DESIGN_SCHEMA"
 
 	// Keys for design code endpoints
 	CreateDesignCodeEndPoint = "CREATE_DESIGN_CODE"
@@ -101,6 +102,7 @@ var URI = map[string]string{
 	GetDesignSchemaEndPoint:    "/users/{{.user}}/designs/{{.designId}}/schemas/{{.version}}",
 	GetDesignSchemasEndPoint:   "/users/{{.user}}/designs/{{.designId}}/schemas",
 	UpdateDesignSchemaEndPoint: "/users/{{.user}}/designs/{{.designId}}/schemas/{{.version}}",
+	DeleteDesignSchemaEndPoint: "/users/{{.user}}/designs/{{.designId}}/schemas/{{.version}}",
 
 	// Design Code
 	CreateDesignCodeEndPoint: "/users/{{.user}}/designs/{{.designId}}/codes",

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -44,6 +44,7 @@ const (
 	DBFieldId            = "id"
 	DBFieldDesignId      = "designid"
 	DBFieldCodes         = "codes"
+	DBFieldSchemas       = "schemas"
 	DBFieldSchemaId      = "schemaid"
 	DBFieldJobId         = "jobid"
 	DBFieldTaskId        = "taskid"


### PR DESCRIPTION
Test Summary:
```
vagrant@flame:/flame/examples/mnist$ flamectl get schemas -d mnist --insecure
Warning: --insecure flag is set; allow insecure connection.
[
    {
        "version": "1",
        "name": "A simple example schema v1.0.0",
        "description": "a sample schema to demostrate a TAG layout",
        "roles": [
            {
                "name": "trainer",
                "description": "It consumes the data and trains local model",
                "isDataConsumer": true
            },
            {
                "name": "aggregator",
                "description": "It aggregates the updates from trainers",
                "replica": 1
            }
        ],
        "channels": [
            {
                "name": "param-channel",
                "description": "Model update is sent from trainer to aggregator and vice-versa",
                "pair": [
                    "trainer",
                    "aggregator"
                ],
                "groupBy": {
                    "type": "tag",
                    "value": [
                        "default/us"
                    ]
                },
                "funcTags": {
                    "aggregator": [
                        "distribute",
                        "aggregate"
                    ],
                    "trainer": [
                        "fetch",
                        "upload"
                    ]
                }
            }
        ]
    }
]


vagrant@flame:/flame/examples/mnist$ flamectl remove schema 1 -d mnist --insecure
Warning: --insecure flag is set; allow insecure connection.
Deleted "bnVsbAo="
 successfully
vagrant@flame:/flame/examples/mnist$ flamectl get schemas -d mnist --insecure
Warning: --insecure flag is set; allow insecure connection.
[]
```
