### PR TITLE
fix: typo and logic error

### DIFF
--- a/lib/python/flame/examples/medmnist/aggregator/config.json
+++ b/lib/python/flame/examples/medmnist/aggregator/config.json
@@ -33,7 +33,7 @@
     ],
     "hyperparameters": {
         "batchSize": 32,
-        "learningRate": 0.01,
+        "learningRate": 0.001,
         "rounds": 5,
 		"epochs": 2
     },
@@ -46,12 +46,16 @@
 	"name": "mednist"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+	"sort": "dummy",
+	"uri": ""
     },
     "selector": {
-	"sort": "random",
-	"kwargs": {"k": 1}
+	"sort": "default",
+	"kwargs": {}
+    },
+    "optimizer": {
+    "sort": "fedavg",
+    "kwargs": {}
     },
     "maxRunTime": 300,
     "realm": "default",

--- a/lib/python/flame/examples/medmnist/trainer/config.json
+++ b/lib/python/flame/examples/medmnist/trainer/config.json
@@ -33,7 +33,7 @@
     ],
     "hyperparameters": {
         "batchSize": 32,
-        "learningRate": 0.01,
+        "learningRate": 0.001,
         "rounds": 5,
 		"epochs": 2
     },
@@ -46,12 +46,16 @@
 	"name": "mednist"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+	"sort": "dummy",
+	"uri": ""
     },
     "selector": {
-	"sort": "random",
-	"kwargs": {"k": 1}
+	"sort": "default",
+	"kwargs": {}
+    },
+    "optimizer": {
+    "sort": "fedavg",
+    "kwargs": {}
     },
     "maxRunTime": 300,
     "realm": "default",

--- a/lib/python/flame/mode/horizontal/middle_aggregator.py
+++ b/lib/python/flame/mode/horizontal/middle_aggregator.py
@@ -89,7 +89,7 @@ class MiddleAggregator(Role, metaclass=ABCMeta):
             return
 
         # this call waits for at least one peer to join this channel
-        channel.wait_join()
+        channel.await_join()
 
         # one aggregator is sufficient
         end = channel.one_end()
@@ -111,7 +111,7 @@ class MiddleAggregator(Role, metaclass=ABCMeta):
             return
 
         # this call waits for at least one peer to join this channel
-        channel.wait_join()
+        channel.await_join()
 
         for end in channel.ends():
             logger.debug(f"sending weights to {end}")

--- a/lib/python/flame/mode/hybrid/trainer.py
+++ b/lib/python/flame/mode/hybrid/trainer.py
@@ -77,9 +77,9 @@ class Trainer(DistTrainer):
         if MessageType.WEIGHTS in msg:
             self.weights = msg[MessageType.WEIGHTS]
             self._update_model()
-        elif MessageType.EOT in msg:
+        if MessageType.EOT in msg:
             self._work_done = msg[MessageType.EOT]
-        elif MessageType.ROUND in msg:
+        if MessageType.ROUND in msg:
             self._round = msg[MessageType.ROUND]
 
         # once global weights were received, let's join ring channel


### PR DESCRIPTION
Fixed a typo in the skeleton code of middle aggregator; fixed a logic error in hybrid skeleton code as a message can contain more than one type of content; updated config file for MedMNIST for latest version of flame.

type | file | changes
-- | -- | --
modified | lib/python/flame/mode/horizontal/middle_aggregator.py | fatal typo
modified | lib/python/flame/mode/hybrid/trainer.py | if/else statement logic error
modified | lib/python/flame/examples/medmnist/aggregator/config.json | remove mlflow
modified | lib/python/flame/examples/medmnist/aggregator/config.json | remove mlflow