### PR TITLE
feat: 'continue' primitive in tasklet

### DIFF
--- a/lib/python/flame/mode/composer.py
+++ b/lib/python/flame/mode/composer.py
@@ -99,9 +99,15 @@ class Composer(object):
             # execute tasklet
             tasklet.do()
 
-            if tasklet.is_last_in_loop() and not tasklet.is_loop_done():
-                # we reached the last tasklet of a loop
-                # but the loop exit condition is not met
+            if tasklet.is_continue() or (tasklet.is_last_in_loop()
+                                         and not tasklet.is_loop_done()):
+                # we are here due to one of the following conditions:
+                #
+                # contition 1: tasklet's continue condition is met;
+                #              so, we skip the remaing tasklets in the loop
+                #              and go back to the start of the loop
+                # condition 2: we reached the last tasklet of a loop
+                #              but the loop exit condition is not met
                 start, end = tasklet.loop_starter, tasklet
                 tasklets_in_loop = self.get_tasklets_in_loop(start, end)
 

--- a/lib/python/flame/mode/horizontal/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/top_aggregator.py
@@ -119,11 +119,11 @@ class TopAggregator(Role, metaclass=ABCMeta):
 
             if MessageType.DATASET_SIZE in msg:
                 count = msg[MessageType.DATASET_SIZE]
-                total += count
 
             logger.debug(f"{end}'s parameters trained with {count} samples")
 
-            if weights is not None:
+            if weights is not None and count > 0:
+                total += count
                 tres = TrainResult(weights, count)
                 # save training result from trainer in a disk cache
                 self.cache[end] = tres

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='flame',
-    version='0.0.11',
+    version='0.0.12',
     author='Flame Maintainers',
     author_email='flame-github-owners@cisco.com',
     include_package_data=True,


### PR DESCRIPTION
We add 'continue' primitive in the tasklet code of the flame library. The 'continue' primitive is used to move back to the start of loop when a certain condition is met. A condition is defined as a function, which will be set via set_continue_fn member function.

As an example use case of 'continue' primitive, a middle aggregator code is extended in the following way: If no trainer join a channel that the middle aggregator is waiting on for a minute, the middle aggregator gives up waiting and updates the top aggregator with dummy weights so that the top aggregator can be unblocked. Then, the middle aggregator goes back to the start of the loop so that it can retrieve model weights of a new global model from the top aggregator.