### PR TITLE
CI/CD add github publish action on release to push docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ciscoresearch/flame
+
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: build/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,9 +17,6 @@
 FROM golang:1.17.8-buster AS golang-build
 WORKDIR /src
 ENV CGO_ENABLED=0
-RUN --mount=target=. \
-    --mount=type=cache,target=/root/.cache/go-build \
-    go test -v ./...
 
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \


### PR DESCRIPTION
1. Adds separate workflow for docker build and publish
2. Adds job trigger only on new release tag publish
3. Adds release tag as docker image tag