### PR TITLE
fix: mlflow flavor "keras" not found

### DIFF
--- a/lib/python/flame/registry/mlflow.py
+++ b/lib/python/flame/registry/mlflow.py
@@ -29,8 +29,12 @@ logger = logging.getLogger(__name__)
 
 # The following flavors are integrated with flame.
 module_to_flavor: dict[str, str] = {
-    "keras": "keras",
+    # keras module is replaced with tensorflow; hence, keras module is
+    # redirected to tensorflow module
+    # see https://github.com/mlflow/mlflow/blame/master/mlflow/keras.py#L3
+    "keras": "tensorflow",
     "sklearn": "sklearn",
+    "tensorflow": "tensorflow",
     "torch": "pytorch"
 }
 
@@ -90,10 +94,11 @@ class MLflowRegistryClient(AbstractRegistryClient):
             return
 
         mlflow.log_params(hyperparameters)
-    
+
     def save_artifact(self, local_path: str) -> None:
         """Save an artifact in a model registry."""
-        mlflow.log_artifact(local_path) # path could be a path to a file or a directory
+        # local_path can be a path to a file or a directory
+        mlflow.log_artifact(local_path)
 
     def cleanup(self) -> None:
         """

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='flame',
-    version='0.0.12',
+    version='0.0.13',
     author='Flame Maintainers',
     author_email='flame-github-owners@cisco.com',
     include_package_data=True,
@@ -36,7 +36,7 @@ setup(
         'boto3',
         'cloudpickle',
         'diskcache',
-        'mlflow',
+        'mlflow==2.0.1',
         'paho-mqtt',
         'protobuf==3.19.5',
     ],


### PR DESCRIPTION
In mlflow 2.0 or above, keras is not provided as a separate module. Instead, tensorflow module is used. When mlflow.keras is imported, mlflow.tensorflow is simply imported. So, trying to do getattr with string "keras" fails because there is no module called keras.

To fix the issue, when keras is identified, we use tensorflow flavor and call getattr with "tensorflow".