### PR TITLE
Deployer Registration Changes

### DIFF
--- a/api/computes_components.partials.yml
+++ b/api/computes_components.partials.yml
@@ -23,15 +23,25 @@ ComputeSpec:
   properties:
     adminId:
       type: string
-    region:
-      type: string
     apiKey:
       type: string
     computeId:
       type: string
+    realm:
+      type: array
+      items:
+        type: string
+    property:
+      type: object
+      additionalProperties:
+        type: string
+  required:
+    - adminId
+    - apiKey
+    - realm
   example:
     adminId: "admin-1"
-    region: "us-east"
+    realm: ["us-east", "us"]
     apiKey: "apikey-1"
     computeId: "compute-1"
 

--- a/cmd/controller/app/database/mongodb/compute.go
+++ b/cmd/controller/app/database/mongodb/compute.go
@@ -31,6 +31,8 @@ import (
 
 // RegisterCompute creates a new cluster compute specification and returns ComputeStatus
 func (db *MongoService) RegisterCompute(computeSpec openapi.ComputeSpec) (openapi.ComputeStatus, error) {
+	//TODO instead of doing a fineOne DB call, use insert API response to determine if the document is already present.
+
 	// First check if the compute was previously registered
 	filter := bson.M{util.DBFieldComputeId: computeSpec.ComputeId}
 	checkResult := db.computeCollection.FindOne(context.TODO(), filter)

--- a/examples/sample_experiment/deployer_config.json
+++ b/examples/sample_experiment/deployer_config.json
@@ -1,0 +1,11 @@
+{
+  "computeSpec" : {
+    "adminId" : "local-admin",
+    "apiKey" : "apiKey1",
+    "computeId" : "compute1",
+    "realm" : ["us/east", "us"],
+    "property" : {}
+  },
+  "platform" : "k8s",
+  "namespace" : "local"
+}

--- a/pkg/openapi/model_compute_spec.go
+++ b/pkg/openapi/model_compute_spec.go
@@ -27,17 +27,30 @@ package openapi
 
 // ComputeSpec - Compute specification
 type ComputeSpec struct {
-	AdminId string `json:"adminId,omitempty"`
+	AdminId string `json:"adminId"`
 
-	Region string `json:"region,omitempty"`
-
-	ApiKey string `json:"apiKey,omitempty"`
+	ApiKey string `json:"apiKey"`
 
 	ComputeId string `json:"computeId,omitempty"`
+
+	Realm []string `json:"realm"`
+
+	Property map[string]interface{} `json:"property,omitempty"`
 }
 
 // AssertComputeSpecRequired checks if the required fields are not zero-ed
 func AssertComputeSpecRequired(obj ComputeSpec) error {
+	elements := map[string]interface{}{
+		"adminId": obj.AdminId,
+		"realm":   obj.Realm,
+		"apiKey":  obj.ApiKey,
+	}
+	for name, el := range elements {
+		if isZero := IsZeroValue(el); isZero {
+			return &RequiredError{Field: name}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Region is now called Realm. It is an array of tags used to describe geo-domain of the underlying cluster managed by the deployer. Additionally, a property attribute is added which will be used in the future to provide cluster properties such as GPU/TPU, storage information etc.. Such properties will be used by the ML developer to provide fine-grain specifications about the resources required to run their job.