### PR TITLE
fix: installation script for amzn2

### DIFF
--- a/fiab/flame.sh
+++ b/fiab/flame.sh
@@ -212,7 +212,7 @@ function post_stop_cleanup {
         done
 
         # step 4: create patch file
-        echo "{\"data\": {\"Corefile\": $(jq -R -s < $tmp_file)}}" > $tmp_file
+        echo "{\"data\": {\"Corefile\": $(jq -R -s '.' < $tmp_file)}}" > $tmp_file
 
         # step 5: patch configmap of coredns with the updated dns entries
         kubectl patch configmap coredns \

--- a/fiab/install.sh
+++ b/fiab/install.sh
@@ -54,6 +54,7 @@ function amzn2_installation {
     VERSION="v1.25.0"
     wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
     sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+    sudo ln -s /usr/local/bin/crictl /usr/bin/crictl # create a symbolic link
     rm -f crictl-$VERSION-linux-amd64.tar.gz
 
     # install minikube


### PR DESCRIPTION
In the script, crictl is installed in /usr/local/bin. However, when minikube is executed with sudo, minikube fails to findcrictl. The path needs to be enabled either sudoer's configuration or in root's path, each of which may not be ideal. As a workaround, a symbolic link is created under /usr/bin.

Also, during the testing, flame.sh has a bug of failing to run jq correctly when ./flame.sh stop is executed. This is because the jq's verions is < 1.6. The fix (adding '.') was applied.