### PR TITLE
misc: bump up mongodb chart version in fiab

### DIFF
--- a/fiab/helm-chart/control/Chart.yaml
+++ b/fiab/helm-chart/control/Chart.yaml
@@ -23,7 +23,7 @@ version: 1.0.0
 
 dependencies:
   - name: mongodb
-    version: 10.31.3
+    version: 13.6.2
     repository: https://charts.bitnami.com/bitnami
 
   - name: minio


### PR DESCRIPTION
The current version of helm chart for mongodb was removed from bitnami. A version (13.6.2) for the chart is bumped up.