### PR TITLE
misc: base image update

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -27,7 +27,10 @@ WORKDIR /src
 COPY ./lib/python /src
 RUN python3 setup.py bdist_wheel && cp dist/flame-*.whl /tmp/
 
-FROM myungjinlee/mlpack:cpu
+# available image tags: pytorch-cpu, tensorflow-cpu, allinone-cpu
+#                       pytorch-cuda11.3, tensorflow-cuda11.3, allinone-cuda11.3
+# note: allinone-cuda11.3 is the largest image
+FROM ciscoresearch/mlpack:allinone-cuda11.3
 COPY --from=golang-build /flame/* /usr/bin/
 
 # Install flame python library

--- a/fiab/flame.sh
+++ b/fiab/flame.sh
@@ -50,9 +50,12 @@ function start {
     exposedb=$1
     tag=$2
     if [ "$tag" == "" ]; then
-        helm install --create-namespace --namespace $RELEASE_NAME $RELEASE_NAME helm-chart/control/
+        helm install --create-namespace --namespace $RELEASE_NAME \
+	     $RELEASE_NAME helm-chart/control/
     else
-        helm install --create-namespace --namespace $RELEASE_NAME $RELEASE_NAME helm-chart/control/ --set imageTag=$2
+        helm install --create-namespace --namespace $RELEASE_NAME \
+	     --set imageTag=$2,workerImageTag=$2 \
+	     $RELEASE_NAME helm-chart/control/
     fi
 
     # Wait until mongodb is up


### PR DESCRIPTION
The base image used to build a flame is changed from a cpu version to a cuda 11.3 version. While this increases an image size significantly, it allows users to use gpu-enabled flame image directly without need for them to build one on their own.