### PR TITLE
misc: fix flame slack workspace link error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="docs/images/logo.png" alt="flame logo" width="200"/></p>
 
-[![](https://img.shields.io/badge/Flame-Join%20Slack-brightgreen)](https://join.slack.com/t/flame-slack/shared_invite/zt-1l1o52uyf-8s7D2887~59BtHLFKhymVQ)
+[![](https://img.shields.io/badge/Flame-Join%20Slack-brightgreen)](https://join.slack.com/t/flame-slack/shared_invite/zt-1mprreo9z-FmpGb1UPi43JOFJKyhIqAQ)
 
 Flame is a platform that enables developers to compose and deploy federated learning (FL) training workloads easily.
 The system is comprised of a service (control plane ) and a python library (data plane).


### PR DESCRIPTION
The flame slack workspace link was expired. A new link with no expiration date is created and updated.