### PR TITLE
doc: refactor fiab instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,34 @@ And the library is also responsible for executing FL workloads.
 With extensibility of its library, Flame can support various experimentations and use cases.
 
 ## Getting started
-This repo contains a dev/test environment in a single machine on top of minikube.
+The target runtime environment is Linux. Development has been mainly conducted under macOS environment.
+One should first set up a development environemnt.
+For more details, refer to [here](docs/02-getting-started.md).
+
+Then, users can use a dev/test environment in a single machine on top of minikube.
 The detailed instructions are found [here](docs/03-fiab.md).
 
-## Development setup
-
-The target runtime environment is Linux. Development has been mainly conducted under macOS environment.
-For more details, refer to [here](docs/02-getting-started.md).
+This repo has the following directory structure:
+```
+flame
+ ├── CODE_OF_CONDUCT.md
+ ├── CONTRIBUTING.md
+ ├── LICENSE
+ ├── Makefile -> build/Makefile
+ ├── README.md
+ ├── api (specification of REST API for flame apiserver)
+ ├── build (configuration files for building flame binaries and container image)
+ ├── cmd (source files for flame control plane)
+ ├── docs (document folder)
+ ├── examples (example folder)
+ ├── fiab (dev/test env in a single box)
+ ├── go.mod
+ ├── go.sum
+ ├── lib (python library for core flame data plane)
+ ├── lint.sh
+ ├── pkg (go packages for cmd)
+ └── scripts (utility scripts)
+```
 
 ## Documentation
 

--- a/docs/03-a-ubuntu.md
+++ b/docs/03-a-ubuntu.md
@@ -138,7 +138,24 @@ Run the following command:
 ```bash
 ./flame.sh start
 ```
-During the configuration by `flame.sh`, it asks a password for sudo permission.
+The above command ensures that the latest official flame image from docker hub is used.
+To use a locally developed image, add `--local-img ` in the above command.
+
+**Note**: The following error may occur during the start.
+```console
+Error: INSTALLATION FAILED: failed post-install: timed out waiting for the condition
+```
+This issue may be because container images are large or the Internet connection is slow.
+The issue has been reported in minikube [github](https://github.com/kubernetes/minikube/issues/14789).
+The latest minikube still doesn't contain the patched component (cri-dockerd 0.2.6).
+A workaround is to pull images manually (e.g. `minikube ssh docker pull ciscoresearch/flame:latest`).
+The command `kubectl get pods -n flame` gives a list of pods and their status.
+The pods with `ErrImagePull` or `ImagePullBackOff` status are ones that might be affected by the issue.
+Identifying the required image can be done by running a `kubectl describe` command
+(e.g., `kubectl describe pod -n flame flame-apiserver-5df5fb6bc4-22z6l`);
+the command's output will show details about the pod, including image name and its tag.
+
+During the configuration by `flame.sh`, it may ask a password for sudo permission.
 The reason for this is to add a dns configuration in `/etc/resolver/flame-test`.
 When stopping flame, the script asks again a password to delete `/etc/resolver/flame-test`.
 
@@ -172,13 +189,6 @@ flame-notifier-cf4854cd9-g27wj      1/1     Running   0              7m5s
 postgres-7fd96c847c-6qdpv           1/1     Running   0              7m5s
 ```
 
-If the above output shows `ErrImagePull` or `ImagePullBackOff` as status, it may be because minikube's image pull step got timed out.
-Such an issue occurs because container images are large or the Internet connection is slow.
-The issue has been reported in minikube [github](https://github.com/kubernetes/minikube/issues/14789).
-A workaround is to pull images manually (e.g. `minikube ssh docker pull ciscoresearch/flame:latest`) before deploying pods.
-Identifying the required image can be done by running a `kubectl describe` command
-(e.g., `kubectl describe pod -n flame flame-apiserver-5df5fb6bc4-22z6l`); the command's output will show details about the pod, including image name and its tag.
-
 As a way to test a successful configuration of routing and dns, test with the following commands:
 ```bash
 ping -c 1 apiserver.flame.test
@@ -189,6 +199,7 @@ These ping commands should run successfully without any error. As another altern
 That should return a mlflow's web page.
 
 ## Stopping flame
+Once using flame is done, one can stop flame by running the following command:
 ```bash
 ./flame.sh stop
 ```
@@ -209,10 +220,13 @@ The following command creates `config.yaml` under `$HOME/.flame`.
 ```bash
 ./build-config.sh
 ```
-The flame CLI tool, `flamectl` uses the configuration file to interact with the flame system.
-In order to build, `flamectl`, run `make install` from the level folder (i.e., `flame`).
+
+## Building flamectl
+The flame CLI tool, `flamectl` uses the configuration file (`config.yaml`) to interact with the flame system.
+In order to build `flamectl`, run `make install` from the level folder (i.e., `flame`).
 This command compiles source code and installs `flamectl` binary as well as other binaries into `$HOME/.flame/bin`.
-You may want to add `export PATH="$HOME/.flame/bin:$PATH"` to your shell config (e.g., `~/.zshrc`, `~/.bashrc`) and then restart your terminal.
+You may want to add `export PATH="$HOME/.flame/bin:$PATH"` to your shell config (e.g., `~/.zshrc`, `~/.bashrc`) and then reload your shell config (e.g., `source ~/.bashrc`).
+The examples in [here](04-examples.md) assume that `flamectl` is in `$HOME/.flame/bin` and the path (`$HOME/.flame/bin`) is exported.
 
 ## Cleanup
 To terminate the fiab environment, run the following:

--- a/docs/03-c-mac.md
+++ b/docs/03-c-mac.md
@@ -171,6 +171,23 @@ Run the following command:
 ```bash
 ./flame.sh start
 ```
+The above command ensures that the latest official flame image from docker hub is used.
+To use a locally developed image, add `--local-img ` in the above command.
+
+**Note**: The following error may occur during the start.
+```console
+Error: INSTALLATION FAILED: failed post-install: timed out waiting for the condition
+```
+This issue may be because container images are large or the Internet connection is slow.
+The issue has been reported in minikube [github](https://github.com/kubernetes/minikube/issues/14789).
+The latest minikube still doesn't contain the patched component (cri-dockerd 0.2.6).
+A workaround is to pull images manually (e.g. `minikube ssh docker pull ciscoresearch/flame:latest`).
+The command `kubectl get pods -n flame` gives a list of pods and their status.
+The pods with `ErrImagePull` or `ImagePullBackOff` status are ones that might be affected by the issue.
+Identifying the required image can be done by running a `kubectl describe` command
+(e.g., `kubectl describe pod -n flame flame-apiserver-5df5fb6bc4-22z6l`);
+the command's output will show details about the pod, including image name and its tag.
+
 During the configuration by `flame.sh`, it asks a password for sudo permission.
 The reason for this is to add a dns configuration in `/etc/resolver/flame-test`.
 When stopping flame, the script asks again a password to delete `/etc/resolver/flame-test`.
@@ -205,13 +222,6 @@ flame-notifier-cf4854cd9-g27wj      1/1     Running   0              7m5s
 postgres-7fd96c847c-6qdpv           1/1     Running   0              7m5s
 ```
 
-If the above output shows `ErrImagePull` or `ImagePullBackOff` as status, it may be because minikube's image pull step got timed out.
-Such an issue occurs because container images are large or the Internet connection is slow.
-The issue has been reported in minikube [github](https://github.com/kubernetes/minikube/issues/14789).
-A workaround is to pull images manually (e.g. `minikube ssh docker pull ciscoresearch/flame:latest`) before deploying pods.
-Identifying the required image can be done by running a `kubectl describe` command
-(e.g., `kubectl describe pod -n flame flame-apiserver-5df5fb6bc4-22z6l`); the command's output will show details about the pod, including image name and its tag.
-
 As a way to test a successful configuration of routing and dns, test with the following commands:
 ```bash
 ping -c 1 apiserver.flame.test
@@ -222,6 +232,7 @@ These ping commands should run successfully without any error. As another altern
 That should return a mlflow's web page.
 
 ## Stopping flame
+Once using flame is done, one can stop flame by running the following command:
 ```bash
 ./flame.sh stop
 ```
@@ -242,10 +253,13 @@ The following command creates `config.yaml` under `$HOME/.flame`.
 ```bash
 ./build-config.sh
 ```
-The flame CLI tool, `flamectl` uses the configuration file to interact with the flame system.
-In order to build, `flamectl`, run `make install` from the level folder (i.e., `flame`).
+
+## Building flamectl
+The flame CLI tool, `flamectl` uses the configuration file (`config.yaml`) to interact with the flame system.
+In order to build `flamectl`, run `make install` from the level folder (i.e., `flame`).
 This command compiles source code and installs `flamectl` binary as well as other binaries into `$HOME/.flame/bin`.
-You may want to add `export PATH="$HOME/.flame/bin:$PATH"` to your shell config (e.g., `~/.zshrc`, `~/.bashrc`) and then restart your terminal.
+You may want to add `export PATH="$HOME/.flame/bin:$PATH"` to your shell config (e.g., `~/.zshrc`, `~/.bashrc`) and then reload your shell config (e.g., `source ~/.bashrc`).
+The examples in [here](04-examples.md) assume that `flamectl` is in `$HOME/.flame/bin` and the path (`$HOME/.flame/bin`) is exported.
 
 ## Cleanup
 To terminate the fiab environment, run the following:

--- a/docs/04-examples.md
+++ b/docs/04-examples.md
@@ -1,11 +1,17 @@
 # Examples
 
-This section currently presents one example: FL training for MNIST. More examples will follow in the future, and you will find the instruction under the README file of their particular folder.
+This section showcases one example: FL training for MNIST. More examples are found under examples folder below the top level folder (i.e.,`flame`).
+You will find the instructions in the README.md file of each example folder.
 
 ## MNIST
 
 Here we go over how to run MNIST example with [fiab](03-fiab.md) environment.
-If `flamectl` command is not found, please refer to [fiab](03-fiab.md).
+The MNIST example is under `flame/examples/mnist`.
+We assume that the current work directory is `flame`.
+Change the working directory to mnist by executing the following:
+```bash
+cd examples/mnist
+```
 
 ### Caution
 Note: all the components in the fiab environment uses a selfsigned certificate.
@@ -17,6 +23,8 @@ $ flamectl create design mnist
 Failed to create a new design - code: -1, error: Post "https://apiserver.flame.test/foo/designs": x509: certificate signed by unknown authority
 ```
 Note that `--insecure` flag should be used with caution and shouldn't be used in production.
+
+If you get an error saying that `flamectl not found`, please refer to [here](03-c-mac.md#Building-flamectl).
 
 ### Step 1: create a design
 ```bash


### PR DESCRIPTION
The workaround for the image pull timeout issue is placed in a wrong section, which makes it hard for users to apply the workaround. The instructions were refactored for better readability.