### PR TITLE
misc: add license header

### DIFF
--- a/cmd/controller/app/database/mongodb/code_test.go
+++ b/cmd/controller/app/database/mongodb/code_test.go
@@ -1,3 +1,19 @@
+// Copyright 2023 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package mongodb
 
 import (

--- a/cmd/controller/app/database/mongodb/compute_test.go
+++ b/cmd/controller/app/database/mongodb/compute_test.go
@@ -1,3 +1,19 @@
+// Copyright 2023 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package mongodb
 
 import (

--- a/cmd/controller/app/database/mongodb/design_test.go
+++ b/cmd/controller/app/database/mongodb/design_test.go
@@ -1,3 +1,19 @@
+// Copyright 2023 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package mongodb
 
 import (

--- a/cmd/controller/app/database/mongodb/schema_test.go
+++ b/cmd/controller/app/database/mongodb/schema_test.go
@@ -1,3 +1,19 @@
+// Copyright 2023 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package mongodb
 
 import (

--- a/scripts/license_header.txt
+++ b/scripts/license_header.txt
@@ -1,4 +1,4 @@
-Copyright 2022 Cisco Systems, Inc. and its affiliates
+Copyright 2023 Cisco Systems, Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
A few source files are missing the license header. The license header is added to them. And also year has been updated.