### PR TITLE
fix: conflict bewtween integer tensor and float tensor

### DIFF
--- a/lib/python/flame/optimizer/fedavg.py
+++ b/lib/python/flame/optimizer/fedavg.py
@@ -86,7 +86,18 @@ class FedAvg(AbstractOptimizer):
         logger.debug("calling _aggregate_pytorch")
 
         for k, v in tres.weights.items():
-            self.agg_weights[k] += v * rate
+            tmp = v * rate
+            # tmp.dtype is always float32 or double as rate is float
+            # if v.dtype is integer (int32 or int64), there is type mismatch
+            # this leads to the following error when self.agg_weights[k] += tmp:
+            #   RuntimeError: result type Float can't be cast to the desired
+            #   output type Long
+            # To handle this issue, we typecast tmp to the original type of v
+            #
+            # TODO: this may need to be revisited
+            tmp = tmp.to(dtype=v.dtype) if tmp.dtype != v.dtype else tmp
+
+            self.agg_weights[k] += tmp
 
     def _aggregate_tensorflow(self, tres, rate):
         logger.debug("calling _aggregate_tensorflow")


### PR DESCRIPTION
## Description

Model architectures can have integer tensors. Applying aggregation on those tensors results in type mistmatch and throws a runtime error: "RuntimeError: result type Float can't be cast to the desired output type Long"

Integer tensors don't matter in back propagation. So, as a workaround to the issue, we typecast to the original dtype when the original type is different from the dtype of weighted tensors for aggregation. In this way, we can keep the model architecture as is.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
