### PR TITLE
Add per channel backend configuration

### DIFF
--- a/api/design_components.partials.yml
+++ b/api/design_components.partials.yml
@@ -127,6 +127,10 @@ Role:
     replica:
       format: int32
       type: integer
+    groupAssociation:
+      type: array
+      items:
+        $ref: '#/components/schemas/GroupAssociation'
   required:
     - name
   example:
@@ -136,6 +140,17 @@ Role:
     - name: aggregator
       description: These are responsible to aggregate the updates from trainer nodes.
       replica: 2
+
+#########################
+# GroupAssociation
+#########################
+GroupAssociation:
+  type: object
+  additionalProperties:
+    type: string
+  example:
+    "param-channel": "red"
+    "global-channel": "black"
 
 #########################
 # Channel between roles

--- a/api/design_components.partials.yml
+++ b/api/design_components.partials.yml
@@ -79,11 +79,14 @@ DesignSchema:
       type: array
       items:
         $ref: '#/components/schemas/Connector'
+    defaultBackend:
+      $ref: '#/components/schemas/CommBackend'
   required:
     - version
     - name
     - roles
     - channels
+    - defaultBackend
   example:
     - name: sample schema 1
       description: Sample schema to demostrate a TAG layout.
@@ -97,10 +100,12 @@ DesignSchema:
         - name: global_aggregator
           description: It is responsible to aggregate the updates from all the aggregators and make a generic model.
           replica: 2
-      channel:
+      defaultBackend: mqtt
+      channels:
         - name: trainer-agg-channel
           description: Model update is sent from trainer to aggregator and vice-versa.
           pair: ["trainer", "aggregator"]
+          backend: p2p
           groupBy:
             type: tag
             value: ["us", "eu"]
@@ -199,6 +204,8 @@ Channel:
           type: string
     isUnidirectional:
       type: boolean
+    backend:
+      $ref: '#/components/schemas/CommBackend'
   required:
     - name
     - pair
@@ -207,6 +214,7 @@ Channel:
     - name: directionalExample
       description: An example to demostrate bi-directional channel creation. Data is sent from trainer to aggregator and vice-versa.
       pair: ["trainer", "aggregator"]
+      backend: p2p
       groupBy:
         type: tag
         value: ["us", "eu"]
@@ -218,6 +226,15 @@ Channel:
         type: tag
         value: ["us", "eu"]
       isUnidirectional: false
+      backend: mqtt
+
+#########################
+# Communication Backends
+#########################
+CommBackend:
+  enum:
+    - mqtt
+    - p2p
 
 #########################
 # Connectors for channels

--- a/api/job_components.partials.yml
+++ b/api/job_components.partials.yml
@@ -39,8 +39,6 @@ JobSpec:
       $ref: '#/components/schemas/Selector'
     priority:
       $ref: '#/components/schemas/JobPriority'
-    backend:
-      $ref: '#/components/schemas/CommBackend'
     maxRunTime:
       type: integer
       format: int32
@@ -67,7 +65,6 @@ JobSpec:
       kwargs:
         k: 10
     prority: "low"
-    backend: "mqtt"
     maxRunTime: 600
     baseModel:
         name: mnist-624d9fc43395791
@@ -78,16 +75,14 @@ JobSpec:
     dependencies:
       - numpy >= 1.2.0
 
+#########################
+# Job Priority
+#########################
 JobPriority:
   enum:
     - low
     - medium
     - high
-
-CommBackend:
-  enum:
-    - mqtt
-    - p2p
 
 ########################################
 # Base Model

--- a/cmd/controller/app/job/builder.go
+++ b/cmd/controller/app/job/builder.go
@@ -171,19 +171,19 @@ func (b *JobBuilder) getTaskTemplates() ([]string, map[string]*taskTemplate) {
 
 	for _, role := range b.schema.Roles {
 		template := &taskTemplate{}
-		JobConfig := &template.JobConfig
+		jobConfig := &template.JobConfig
 
-		JobConfig.Configure(b.jobSpec, b.jobParams.Brokers, b.jobParams.Registry, role, b.schema.Channels)
+		jobConfig.Configure(b.jobSpec, b.jobParams.Brokers, b.jobParams.Registry, role, b.schema.Channels)
 
-		// check channels and set default group if channels don't have groupby attributes set
-		for i := range JobConfig.Channels {
-			if len(JobConfig.Channels[i].GroupBy.Value) > 0 {
+		// check channels and set default group if channels don't have groupBy attributes set
+		for i := range jobConfig.Channels {
+			if len(jobConfig.Channels[i].GroupBy.Value) > 0 {
 				continue
 			}
 
-			// since there is no groupby attribute, set default
-			JobConfig.Channels[i].GroupBy.Type = groupByTypeTag
-			JobConfig.Channels[i].GroupBy.Value = append(JobConfig.Channels[i].GroupBy.Value, defaultGroup)
+			// since there is no groupBy attribute, set default
+			jobConfig.Channels[i].GroupBy.Type = groupByTypeTag
+			jobConfig.Channels[i].GroupBy.Value = append(jobConfig.Channels[i].GroupBy.Value, defaultGroup)
 		}
 
 		template.isDataConsumer = role.IsDataConsumer
@@ -192,7 +192,7 @@ func (b *JobBuilder) getTaskTemplates() ([]string, map[string]*taskTemplate) {
 		}
 		template.ZippedCode = b.roleCode[role.Name]
 		template.Role = role.Name
-		template.JobId = JobConfig.Job.Id
+		template.JobId = jobConfig.Job.Id
 
 		templates[role.Name] = template
 	}
@@ -205,9 +205,9 @@ func (b *JobBuilder) preCheck(dataRoles []string, templates map[string]*taskTemp
 	// This function will evolve as more invariants are defined
 	// Before processing templates, the following invariants should be met:
 	// 1. At least one data consumer role should be defined.
-	// 2. a role shouled be associated with a code.
+	// 2. a role should be associated with a code.
 	// 3. template should be connected.
-	// 4. when graph traversal starts at a data role template, the depth of groupby tag
+	// 4. when graph traversal starts at a data role template, the depth of groupBy tag
 	//    should strictly decrease from one channel to another.
 	// 5. two different data roles cannot be connected directly.
 

--- a/cmd/controller/app/job/builder.go
+++ b/cmd/controller/app/job/builder.go
@@ -173,17 +173,23 @@ func (b *JobBuilder) getTaskTemplates() ([]string, map[string]*taskTemplate) {
 		template := &taskTemplate{}
 		jobConfig := &template.JobConfig
 
+		// set the default communication protocol
+		jobConfig.DefaultBackend = b.schema.DefaultBackend
+
 		jobConfig.Configure(b.jobSpec, b.jobParams.Brokers, b.jobParams.Registry, role, b.schema.Channels)
 
-		// check channels and set default group if channels don't have groupBy attributes set
+		// check channels and set default group if channels don't have groupby attributes set
 		for i := range jobConfig.Channels {
-			if len(jobConfig.Channels[i].GroupBy.Value) > 0 {
-				continue
+			// check for channel's backend. If not present update it with default value
+			if len(jobConfig.Channels[i].Backend) == 0 {
+				jobConfig.Channels[i].Backend = b.schema.DefaultBackend
 			}
 
-			// since there is no groupBy attribute, set default
-			jobConfig.Channels[i].GroupBy.Type = groupByTypeTag
-			jobConfig.Channels[i].GroupBy.Value = append(jobConfig.Channels[i].GroupBy.Value, defaultGroup)
+			if len(jobConfig.Channels[i].GroupBy.Value) == 0 {
+				// check channels and set default group if channel doesn't have groupBy attributes set
+				jobConfig.Channels[i].GroupBy.Type = groupByTypeTag
+				jobConfig.Channels[i].GroupBy.Value = append(jobConfig.Channels[i].GroupBy.Value, defaultGroup)
+			}
 		}
 
 		template.isDataConsumer = role.IsDataConsumer

--- a/cmd/controller/app/job/builder_test.go
+++ b/cmd/controller/app/job/builder_test.go
@@ -34,7 +34,6 @@ var (
 		DesignId:        "test",
 		SchemaVersion:   "1",
 		CodeVersion:     "1",
-		Backend:         "mqtt",
 		MaxRunTime:      300,
 		Hyperparameters: map[string]interface{}{"batchSize": 32, "rounds": 5},
 		Dependencies:    []string{"numpy >= 1.2.0"},

--- a/cmd/controller/app/objects/task.go
+++ b/cmd/controller/app/objects/task.go
@@ -50,6 +50,7 @@ type JobConfig struct {
 	Job      JobIdName         `json:"job"`
 	Role     string            `json:"role"`
 	Realm    string            `json:"realm"`
+	Groups   map[string]string `json:"groups"`
 	Channels []openapi.Channel `json:"channels"`
 
 	MaxRunTime      int32                  `json:"maxRunTime,omitempty"`
@@ -101,6 +102,22 @@ func (cfg *JobConfig) Configure(jobSpec *openapi.JobSpec, brokers []config.Broke
 	// Realm will be updated when datasets are handled
 	cfg.Realm = ""
 	cfg.Channels = cfg.extractChannels(role.Name, channels)
+
+	// configure the groups of the job based on the groups associated with the assigned role
+	cfg.Groups = cfg.extractGroups(role.GroupAssociation)
+}
+
+// extractGroups - extracts the associated groups that a given role has of a particular job
+func (cfg *JobConfig) extractGroups(groupAssociation []map[string]string) map[string]string {
+	groups := make(map[string]string)
+
+	for _, ag := range groupAssociation {
+		for key, value := range ag {
+			groups[key] = value
+		}
+	}
+
+	return groups
 }
 
 func (cfg *JobConfig) extractChannels(role string, channels []openapi.Channel) []openapi.Channel {

--- a/cmd/controller/app/objects/task.go
+++ b/cmd/controller/app/objects/task.go
@@ -44,15 +44,14 @@ type JobIdName struct {
 }
 
 type JobConfig struct {
-	BackEnd  string            `json:"backend"`
-	Brokers  []config.Broker   `json:"brokers,omitempty"`
-	Registry config.Registry   `json:"registry,omitempty"`
-	Job      JobIdName         `json:"job"`
-	Role     string            `json:"role"`
-	Realm    string            `json:"realm"`
-	Groups   map[string]string `json:"groups"`
-	Channels []openapi.Channel `json:"channels"`
-
+	Brokers         []config.Broker        `json:"brokers,omitempty"`
+	Registry        config.Registry        `json:"registry,omitempty"`
+	Job             JobIdName              `json:"job"`
+	Role            string                 `json:"role"`
+	Realm           string                 `json:"realm"`
+	Groups          map[string]string      `json:"groups"`
+	Channels        []openapi.Channel      `json:"channels"`
+	DefaultBackend  openapi.CommBackend    `json:"defaultBackend"`
 	MaxRunTime      int32                  `json:"maxRunTime,omitempty"`
 	BaseModel       openapi.BaseModel      `json:"baseModel,omitempty"`
 	Hyperparameters map[string]interface{} `json:"hyperparameters,omitempty"`
@@ -92,7 +91,6 @@ func (cfg *JobConfig) Configure(jobSpec *openapi.JobSpec, brokers []config.Broke
 	cfg.Optimizer = jobSpec.Optimizer
 	cfg.Selector = jobSpec.Selector
 	cfg.Dependencies = jobSpec.Dependencies
-	cfg.BackEnd = string(jobSpec.Backend)
 	cfg.Brokers = brokers
 	cfg.Registry = registry
 	// Dataset url will be populated when datasets are handled
@@ -131,25 +129,3 @@ func (cfg *JobConfig) extractChannels(role string, channels []openapi.Channel) [
 
 	return exChannels
 }
-
-/*
-// For debugging purpose during development
-func (jc JobConfig) Print() {
-	zap.S().Debug("---")
-	zap.S().Debugf("backend: %s\n", jc.BackEnd)
-	zap.S().Debugf("broker: %s\n", jc.Broker)
-	zap.S().Debugf("JobId: %s\n", jc.JobId)
-	zap.S().Debugf("Role: %s\n", jc.Role)
-	zap.S().Debugf("Realm: %s\n", jc.Realm)
-	for i, channel := range jc.Channels {
-		zap.S().Debugf("\t[%d] channel: %v\n", i, channel)
-	}
-
-	zap.S().Debugf("MaxRunTime: %d\n", jc.MaxRunTime)
-	zap.S().Debugf("BaseModelId: %s\n", jc.BaseModelId)
-	zap.S().Debugf("Hyperparameters: %v\n", jc.Hyperparameters)
-	zap.S().Debugf("Dependencies: %v\n", jc.Dependencies)
-	zap.S().Debugf("DatasetUrl: %s\n", jc.DatasetUrl)
-	zap.S().Debug("")
-}
-*/

--- a/examples/adult/job.json
+++ b/examples/adult/job.json
@@ -9,10 +9,7 @@
         "fromSystem": []
     },
     "priority": "low",
-
-    "backend": "mqtt",
     "maxRunTime": 1800,
-
     "baseModel": {
         "name": "",
         "version": 0
@@ -20,7 +17,7 @@
     "hyperparameters": {
         "rounds": 5
     },
-    "dependencies" : [
+    "dependencies": [
         "numpy >= 1.2.0"
     ],
     "selector": {

--- a/examples/adult/schema.json
+++ b/examples/adult/schema.json
@@ -2,34 +2,51 @@
     "name": "A simple two-tier topology schema",
     "description": "a sample schema to demonstrate a TAG layout",
     "roles": [
-	{
-	    "name": "trainer",
-	    "description": "It consumes the data and trains local model",
-	    "isDataConsumer": true
-	},
-	{
-	    "name": "aggregator",
-	    "description": "It aggregates the updates from trainers"
-	}
+        {
+            "name": "trainer",
+            "description": "It consumes the data and trains local model",
+            "isDataConsumer": true,
+            "groupAssociation": [
+                {
+                    "param-channel": "default"
+                }
+            ]
+        },
+        {
+            "name": "aggregator",
+            "description": "It aggregates the updates from trainers",
+            "replica": 1,
+            "groupAssociation": [
+                {
+                    "param-channel": "default"
+                }
+            ]
+        }
     ],
     "channels": [
-	{
-	    "name": "param-channel",
-	    "description": "Model update is sent from trainer to aggregator and vice-versa",
-	    "pair": [
-		"trainer",
-		"aggregator"
-	    ],
-	    "groupBy": {
-		"type": "tag",
-		"value": [
-		    "default"
-		]
-	    },
-	    "funcTags": {
-		"trainer": ["fetch", "upload"],
-		"aggregator": ["distribute", "aggregate"]
-	    }
-	}
+        {
+            "name": "param-channel",
+            "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "pair": [
+                "trainer",
+                "aggregator"
+            ],
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default"
+                ]
+            },
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
+            }
+        }
     ]
 }

--- a/examples/adult/schema.json
+++ b/examples/adult/schema.json
@@ -23,10 +23,12 @@
             ]
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "name": "param-channel",
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "pair": [
                 "trainer",
                 "aggregator"

--- a/examples/distributed_training/dataset_1.json
+++ b/examples/distributed_training/dataset_1.json
@@ -1,15 +1,9 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist_1.npz",
-
     "//": "the url is a fake url, serving as a placeholder. Data-loading are hard-coded by users in trainer's python script for simplicity and demonstration purpose.",
-
     "dataFormat": "npy",
-
     "realm": "default/us/org",
-
     "isPublic": true
 }

--- a/examples/distributed_training/dataset_2.json
+++ b/examples/distributed_training/dataset_2.json
@@ -1,15 +1,9 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist_2.npz",
-
     "//": "the url is a fake url, serving as a placeholder. Data-loading are hard-coded by users in trainer's python script for simplicity and demonstration purpose.",
-
     "dataFormat": "npy",
-
     "realm": "default/us/org",
-
     "isPublic": true
 }

--- a/examples/distributed_training/dataset_3.json
+++ b/examples/distributed_training/dataset_3.json
@@ -1,15 +1,9 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist_3.npz",
-
     "//": "the url is a fake url, serving as a placeholder. Data-loading are hard-coded by users in trainer's python script for simplicity and demonstration purpose.",
-
     "dataFormat": "npy",
-
     "realm": "default/us/org",
-
     "isPublic": true
 }

--- a/examples/distributed_training/job.json
+++ b/examples/distributed_training/job.json
@@ -13,10 +13,7 @@
         ]
     },
     "priority": "low",
-
-    "backend": "mqtt",
     "maxRunTime": 1800,
-
     "baseModel": {
         "name": "",
         "version": 0
@@ -26,7 +23,7 @@
         "batchSize": 32,
         "learningRate": 0.01
     },
-    "dependencies" : [
+    "dependencies": [
         "numpy >= 1.2.0"
     ],
     "selector": {

--- a/examples/distributed_training/schema.json
+++ b/examples/distributed_training/schema.json
@@ -2,11 +2,16 @@
     "name": "A simple schema for distributed training with MQTT backend",
     "description": "This implementation is on Keras using MNIST dataset.",
     "roles": [
-	{
-	    "name": "trainer",
-	    "description": "It consumes the data and trains local model",
-	    "isDataConsumer": true
-	}
+        {
+            "name": "trainer",
+            "description": "It consumes the data and trains local model",
+            "isDataConsumer": true,
+            "groupAssociation": [
+                {
+                    "param-channel": "default/us"
+                }
+            ]
+        }
     ],
     "channels": [
         {
@@ -22,8 +27,10 @@
                 "trainer",
                 "trainer"
             ],
-	    "funcTags": {
-                "trainer": ["ring_allreduce"]
+            "funcTags": {
+                "trainer": [
+                    "ring_allreduce"
+                ]
             }
         }
     ]

--- a/examples/distributed_training/schema.json
+++ b/examples/distributed_training/schema.json
@@ -13,9 +13,11 @@
             ]
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from a trainer to another trainer",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [

--- a/examples/hier_mnist/dataset_eu_germany.json
+++ b/examples/hier_mnist/dataset_eu_germany.json
@@ -1,15 +1,9 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist_1.npz",
-
     "//": "the url is a fake url, serving as a placeholder. Data-loading are hard-coded by users in trainer's python script for simplicity and demonstration purpose.",
-
     "dataFormat": "npy",
-
     "realm": "default/eu/germany",
-
     "isPublic": true
 }

--- a/examples/hier_mnist/dataset_eu_uk.json
+++ b/examples/hier_mnist/dataset_eu_uk.json
@@ -1,15 +1,9 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist_2.npz",
-
     "//": "the url is a fake url, serving as a placeholder. Data-loading are hard-coded by users in trainer's python script for simplicity and demonstration purpose.",
-
     "dataFormat": "npy",
-
     "realm": "default/eu/uk",
-
     "isPublic": true
 }

--- a/examples/hier_mnist/dataset_na_canada.json
+++ b/examples/hier_mnist/dataset_na_canada.json
@@ -1,15 +1,9 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist_3.npz",
-
     "//": "the url is a fake url, serving as a placeholder. Data-loading are hard-coded by users in trainer's python script for simplicity and demonstration purpose.",
-
     "dataFormat": "npy",
-
     "realm": "default/na/canada",
-
     "isPublic": true
 }

--- a/examples/hier_mnist/dataset_na_us.json
+++ b/examples/hier_mnist/dataset_na_us.json
@@ -1,15 +1,9 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist_4.npz",
-
     "//": "the url is a fake url, serving as a placeholder. Data-loading are hard-coded by users in trainer's python script for simplicity and demonstration purpose.",
-
     "dataFormat": "npy",
-
     "realm": "default/na/us",
-
     "isPublic": true
 }

--- a/examples/hier_mnist/job.json
+++ b/examples/hier_mnist/job.json
@@ -14,10 +14,7 @@
         ]
     },
     "priority": "low",
-
-    "backend": "mqtt",
     "maxRunTime": 1800,
-
     "baseModel": {
         "name": "",
         "version": 0
@@ -27,7 +24,7 @@
         "batchSize": 32,
         "learningRate": 0.01
     },
-    "dependencies" : [
+    "dependencies": [
         "numpy >= 1.2.0"
     ],
     "selector": {

--- a/examples/hier_mnist/schema.json
+++ b/examples/hier_mnist/schema.json
@@ -2,57 +2,87 @@
     "name": "A simple hierarchical FL MNIST example schema v1.0.0",
     "description": "a sample schema to demostrate the hierarchical FL setting",
     "roles": [
-	{
-	    "name": "trainer",
-	    "description": "It consumes the data and trains local model",
-	    "isDataConsumer": true
-	},
-	{
-	    "name": "middle-aggregator",
-	    "description": "It aggregates the updates from trainers"
-	},
-	{
-	    "name": "top-aggregator",
-	    "description": "It aggregates the updates from middle-aggregator"
-	}
+        {
+            "name": "trainer",
+            "description": "It consumes the data and trains local model",
+            "isDataConsumer": true,
+            "groupAssociation": [
+                {
+                    "param-channel": "default/eu"
+                }
+            ]
+        },
+        {
+            "name": "middle-aggregator",
+            "description": "It aggregates the updates from trainers",
+            "replica": 1,
+            "groupAssociation": [
+                {
+                    "param-channel": "default/us",
+                    "global-channel": "default"
+                }
+            ]
+        },
+        {
+            "name": "top-aggregator",
+            "description": "It aggregates the updates from middle-aggregator",
+            "replica": 1,
+            "groupAssociation": [
+                {
+                    "global-channel": "default"
+                }
+            ]
+        }
     ],
     "channels": [
-	{
-	    "name": "param-channel",
-	    "description": "Model update is sent from trainer to middle-aggregator and vice-versa",
-	    "pair": [
-			"trainer",
-			"middle-aggregator"
-	    ],
-	    "groupBy": {
-		"type": "tag",
-		"value": [
-			"default/eu",
-			"default/na"
-		]
-	    },
-	    "funcTags": {
-		"trainer": ["fetch", "upload"],
-		"middle-aggregator": ["distribute", "aggregate"]
-	    }
-	},
-	{
-	    "name": "global-channel",
-	    "description": "Model update is sent from middle-aggregator to top-aggregator and vice-versa",
-	    "pair": [
-			"top-aggregator",
-			"middle-aggregator"
-	    ],
-	    "groupBy": {
-		"type": "tag",
-		"value": [
-			"default"
-		]
-	    },
-	    "funcTags": {
-		"top-aggregator": ["distribute", "aggregate"],
-		"middle-aggregator": ["fetch", "upload"]
-	    }
-	}
+        {
+            "name": "param-channel",
+            "description": "Model update is sent from trainer to middle-aggregator and vice-versa",
+            "pair": [
+                "trainer",
+                "middle-aggregator"
+            ],
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default/eu",
+                    "default/na"
+                ]
+            },
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "middle-aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
+            }
+        },
+        {
+            "name": "global-channel",
+            "description": "Model update is sent from middle-aggregator to top-aggregator and vice-versa",
+            "pair": [
+                "top-aggregator",
+                "middle-aggregator"
+            ],
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default"
+                ]
+            },
+            "funcTags": {
+                "top-aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "middle-aggregator": [
+                    "fetch",
+                    "upload"
+                ]
+            }
+        }
     ]
 }

--- a/examples/hier_mnist/schema.json
+++ b/examples/hier_mnist/schema.json
@@ -34,10 +34,12 @@
             ]
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "name": "param-channel",
             "description": "Model update is sent from trainer to middle-aggregator and vice-versa",
+            "backend": "mqtt",
             "pair": [
                 "trainer",
                 "middle-aggregator"
@@ -63,6 +65,7 @@
         {
             "name": "global-channel",
             "description": "Model update is sent from middle-aggregator to top-aggregator and vice-versa",
+            "backend": "mqtt",
             "pair": [
                 "top-aggregator",
                 "middle-aggregator"

--- a/examples/medmnist/dataset1.json
+++ b/examples/medmnist/dataset1.json
@@ -1,13 +1,8 @@
 {
     "name": "MedMNIST dataset1",
-
     "description": "Dataset Repo: https://github.com/MedMNIST/MedMNIST, NonIID generating algorithm from FedMA paper repo",
-
     "url": "https://raw.github.com/GaoxiangLuo/flame-datasets/main/site1.npz",
-
     "dataFormat": "npz",
-
     "realm": "default/us/org1",
-
     "isPublic": true
 }

--- a/examples/medmnist/dataset10.json
+++ b/examples/medmnist/dataset10.json
@@ -1,13 +1,8 @@
 {
     "name": "MedMNIST dataset10",
-
     "description": "Dataset Repo: https://github.com/MedMNIST/MedMNIST, NonIID generating algorithm from FedMA paper repo",
-
     "url": "https://raw.github.com/GaoxiangLuo/flame-datasets/main/site10.npz",
-
     "dataFormat": "npz",
-
     "realm": "default/us/org10",
-
     "isPublic": true
 }

--- a/examples/medmnist/dataset2.json
+++ b/examples/medmnist/dataset2.json
@@ -1,13 +1,8 @@
 {
     "name": "MedMNIST dataset2",
-
     "description": "Dataset Repo: https://github.com/MedMNIST/MedMNIST, NonIID generating algorithm from FedMA paper repo",
-
     "url": "https://raw.github.com/GaoxiangLuo/flame-datasets/main/site2.npz",
-
     "dataFormat": "npz",
-
     "realm": "default/us/org2",
-
     "isPublic": true
 }

--- a/examples/medmnist/dataset3.json
+++ b/examples/medmnist/dataset3.json
@@ -1,13 +1,8 @@
 {
     "name": "MedMNIST dataset3",
-
     "description": "Dataset Repo: https://github.com/MedMNIST/MedMNIST, NonIID generating algorithm from FedMA paper repo",
-
     "url": "https://raw.github.com/GaoxiangLuo/flame-datasets/main/site3.npz",
-
     "dataFormat": "npz",
-
     "realm": "default/us/org3",
-
     "isPublic": true
 }

--- a/examples/medmnist/dataset4.json
+++ b/examples/medmnist/dataset4.json
@@ -1,13 +1,8 @@
 {
     "name": "MedMNIST dataset4",
-
     "description": "Dataset Repo: https://github.com/MedMNIST/MedMNIST, NonIID generating algorithm from FedMA paper repo",
-
     "url": "https://raw.github.com/GaoxiangLuo/flame-datasets/main/site4.npz",
-
     "dataFormat": "npz",
-
     "realm": "default/us/org4",
-
     "isPublic": true
 }

--- a/examples/medmnist/dataset5.json
+++ b/examples/medmnist/dataset5.json
@@ -1,13 +1,8 @@
 {
     "name": "MedMNIST dataset5",
-
     "description": "Dataset Repo: https://github.com/MedMNIST/MedMNIST, NonIID generating algorithm from FedMA paper repo",
-
     "url": "https://raw.github.com/GaoxiangLuo/flame-datasets/main/site5.npz",
-
     "dataFormat": "npz",
-
     "realm": "default/us/org5",
-
     "isPublic": true
 }

--- a/examples/medmnist/dataset6.json
+++ b/examples/medmnist/dataset6.json
@@ -1,13 +1,8 @@
 {
     "name": "MedMNIST dataset6",
-
     "description": "Dataset Repo: https://github.com/MedMNIST/MedMNIST, NonIID generating algorithm from FedMA paper repo",
-
     "url": "https://raw.github.com/GaoxiangLuo/flame-datasets/main/site6.npz",
-
     "dataFormat": "npz",
-
     "realm": "default/us/org6",
-
     "isPublic": true
 }

--- a/examples/medmnist/dataset7.json
+++ b/examples/medmnist/dataset7.json
@@ -1,13 +1,8 @@
 {
     "name": "MedMNIST dataset7",
-
     "description": "Dataset Repo: https://github.com/MedMNIST/MedMNIST, NonIID generating algorithm from FedMA paper repo",
-
     "url": "https://raw.github.com/GaoxiangLuo/flame-datasets/main/site7.npz",
-
     "dataFormat": "npz",
-
     "realm": "default/us/org7",
-
     "isPublic": true
 }

--- a/examples/medmnist/dataset8.json
+++ b/examples/medmnist/dataset8.json
@@ -1,13 +1,8 @@
 {
     "name": "MedMNIST dataset8",
-
     "description": "Dataset Repo: https://github.com/MedMNIST/MedMNIST, NonIID generating algorithm from FedMA paper repo",
-
     "url": "https://raw.github.com/GaoxiangLuo/flame-datasets/main/site8.npz",
-
     "dataFormat": "npz",
-
     "realm": "default/us/org8",
-
     "isPublic": true
 }

--- a/examples/medmnist/dataset9.json
+++ b/examples/medmnist/dataset9.json
@@ -1,13 +1,8 @@
 {
     "name": "MedMNIST dataset9",
-
     "description": "Dataset Repo: https://github.com/MedMNIST/MedMNIST, NonIID generating algorithm from FedMA paper repo",
-
     "url": "https://raw.github.com/GaoxiangLuo/flame-datasets/main/site9.npz",
-
     "dataFormat": "npz",
-
     "realm": "default/us/org9",
-
     "isPublic": true
 }

--- a/examples/medmnist/job.json
+++ b/examples/medmnist/job.json
@@ -20,10 +20,7 @@
         ]
     },
     "priority": "low",
-
-    "backend": "mqtt",
     "maxRunTime": 86400,
-
     "baseModel": {
         "name": "",
         "version": 0
@@ -34,7 +31,7 @@
         "learningRate": 0.01,
         "epochs": 4
     },
-    "dependencies" : [
+    "dependencies": [
         "numpy >= 1.2.0"
     ],
     "selector": {

--- a/examples/medmnist/schema.json
+++ b/examples/medmnist/schema.json
@@ -2,34 +2,51 @@
     "name": "Benchmark of FedOPT Aggregators/Optimizers using MedMNIST example schema v1.0.0 via PyTorch",
     "description": "A simple example of MedMNIST using PyTorch to test out different aggregator algorithms.",
     "roles": [
-	{
-	    "name": "trainer",
-	    "description": "It consumes the data and trains local model",
-	    "isDataConsumer": true
-	},
-	{
-	    "name": "aggregator",
-	    "description": "It aggregates the updates from trainers"
-	}
+        {
+            "name": "trainer",
+            "description": "It consumes the data and trains local model",
+            "isDataConsumer": true,
+            "groupAssociation": [
+                {
+                    "param-channel": "default/us"
+                }
+            ]
+        },
+        {
+            "name": "aggregator",
+            "description": "It aggregates the updates from trainers",
+            "replica": 1,
+            "groupAssociation": [
+                {
+                    "param-channel": "default/us"
+                }
+            ]
+        }
     ],
     "channels": [
-	{
-	    "name": "param-channel",
-	    "description": "Model update is sent from trainer to aggregator and vice-versa",
-	    "pair": [
-		    "trainer",
-		    "aggregator"
-	    ],
-	    "groupBy": {
-			"type": "tag",
-			"value": [
-		    	"default/us"
-			]
-	    },
-	    "funcTags": {
-			"trainer": ["fetch", "upload"],
-			"aggregator": ["distribute", "aggregate"]
-	    }
-	}
+        {
+            "name": "param-channel",
+            "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "pair": [
+                "trainer",
+                "aggregator"
+            ],
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default/us"
+                ]
+            },
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
+            }
+        }
     ]
 }

--- a/examples/medmnist/schema.json
+++ b/examples/medmnist/schema.json
@@ -23,10 +23,12 @@
             ]
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "name": "param-channel",
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "pair": [
                 "trainer",
                 "aggregator"

--- a/examples/mnist/dataset.json
+++ b/examples/mnist/dataset.json
@@ -1,13 +1,8 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz",
-
     "dataFormat": "npy",
-
     "realm": "default/us/west",
-
     "isPublic": true
 }

--- a/examples/mnist/job.json
+++ b/examples/mnist/job.json
@@ -11,10 +11,7 @@
         ]
     },
     "priority": "low",
-
-    "backend": "mqtt",
     "maxRunTime": 1800,
-
     "baseModel": {
         "name": "",
         "version": 0
@@ -24,7 +21,7 @@
         "batchSize": 32,
         "learningRate": 0.01
     },
-    "dependencies" : [
+    "dependencies": [
         "numpy >= 1.2.0"
     ],
     "selector": {

--- a/examples/mnist/schema.json
+++ b/examples/mnist/schema.json
@@ -1,36 +1,52 @@
 {
     "name": "A simple example schema v1.0.0",
-    "description": "a sample schema to demostrate a TAG layout",
+    "description": "a sample schema to demonstrate a TAG layout",
     "roles": [
-	{
-	    "name": "trainer",
-	    "description": "It consumes the data and trains local model",
-	    "isDataConsumer": true
-	},
-	{
-	    "name": "aggregator",
-	    "description": "It aggregates the updates from trainers",
-	    "replica": 1
-	}
+        {
+            "name": "trainer",
+            "description": "It consumes the data and trains local model",
+            "isDataConsumer": true,
+            "groupAssociation": [
+                {
+                    "param-channel": "default/us"
+                }
+            ]
+        },
+        {
+            "name": "aggregator",
+            "description": "It aggregates the updates from trainers",
+            "replica": 1,
+            "groupAssociation": [
+                {
+                    "param-channel": "default/us"
+                }
+            ]
+        }
     ],
     "channels": [
-	{
-	    "name": "param-channel",
-	    "description": "Model update is sent from trainer to aggregator and vice-versa",
-	    "pair": [
-		"trainer",
-		"aggregator"
-	    ],
-	    "groupBy": {
-		"type": "tag",
-		"value": [
-		    "default/us"
-		]
-	    },
-	    "funcTags": {
-		"trainer": ["fetch", "upload"],
-		"aggregator": ["distribute", "aggregate"]
-	    }
-	}
+        {
+            "name": "param-channel",
+            "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "pair": [
+                "trainer",
+                "aggregator"
+            ],
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default/us"
+                ]
+            },
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
+            }
+        }
     ]
 }

--- a/examples/mnist/schema.json
+++ b/examples/mnist/schema.json
@@ -23,10 +23,12 @@
             ]
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "name": "param-channel",
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "pair": [
                 "trainer",
                 "aggregator"

--- a/examples/mnist_non_orchestration_mode/job.json
+++ b/examples/mnist_non_orchestration_mode/job.json
@@ -3,30 +3,27 @@
     "schemaVersion": "1",
     "codeVersion": "1",
     "dataSpec": {
-	"fromUser": {
-	    "default": 1
-	},
-	"fromSystem": []
+        "fromUser": {
+            "default": 1
+        },
+        "fromSystem": []
     },
     "priority": "low",
-
-    "backend": "mqtt",
     "maxRunTime": 1800,
-
     "baseModel": {
-	"name": "",
-	"version": 0
+        "name": "",
+        "version": 0
     },
     "hyperparameters": {
-	"rounds": 5,
-	"batchSize": 32,
-	"learningRate": 0.01
+        "rounds": 5,
+        "batchSize": 32,
+        "learningRate": 0.01
     },
-    "dependencies" : [
-	"numpy >= 1.2.0"
+    "dependencies": [
+        "numpy >= 1.2.0"
     ],
     "selector": {
-	"sort": "default",
-	"kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     }
 }

--- a/examples/mnist_non_orchestration_mode/schema.json
+++ b/examples/mnist_non_orchestration_mode/schema.json
@@ -2,35 +2,51 @@
     "name": "A simple example schema v1.0.0",
     "description": "a sample schema to demostrate a TAG layout",
     "roles": [
-	{
-	    "name": "trainer",
-	    "description": "It consumes the data and trains local model",
-	    "isDataConsumer": true
-	},
-	{
-	    "name": "aggregator",
-	    "description": "It aggregates the updates from trainers",
-	    "replica": 1
-	}
+        {
+            "name": "trainer",
+            "description": "It consumes the data and trains local model",
+            "isDataConsumer": true,
+            "groupAssociation": [
+                {
+                    "param-channel": "default"
+                }
+            ]
+        },
+        {
+            "name": "aggregator",
+            "description": "It aggregates the updates from trainers",
+            "replica": 1,
+            "groupAssociation": [
+                {
+                    "param-channel": "default"
+                }
+            ]
+        }
     ],
     "channels": [
-	{
-	    "name": "param-channel",
-	    "description": "Model update is sent from trainer to aggregator and vice-versa",
-	    "pair": [
-		"trainer",
-		"aggregator"
-	    ],
-	    "groupBy": {
-		"type": "tag",
-		"value": [
-		    "default"
-		]
-	    },
-	    "funcTags": {
-		"trainer": ["fetch", "upload"],
-		"aggregator": ["distribute", "aggregate"]
-	    }
-	}
+        {
+            "name": "param-channel",
+            "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "pair": [
+                "trainer",
+                "aggregator"
+            ],
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default"
+                ]
+            },
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
+            }
+        }
     ]
 }

--- a/examples/mnist_non_orchestration_mode/schema.json
+++ b/examples/mnist_non_orchestration_mode/schema.json
@@ -23,10 +23,12 @@
             ]
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "name": "param-channel",
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "pair": [
                 "trainer",
                 "aggregator"

--- a/examples/parallel_experiment/dataset_asia_china.json
+++ b/examples/parallel_experiment/dataset_asia_china.json
@@ -1,15 +1,9 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist_5.npz",
-
     "//": "the url is a fake url, serving as a placeholder. Data-loading are hard-coded by users in trainer's python script for simplicity and demonstration purpose.",
-
     "dataFormat": "npy",
-
     "realm": "default/asia/china",
-
     "isPublic": true
 }

--- a/examples/parallel_experiment/dataset_eu_uk.json
+++ b/examples/parallel_experiment/dataset_eu_uk.json
@@ -1,15 +1,9 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist_2.npz",
-
     "//": "the url is a fake url, serving as a placeholder. Data-loading are hard-coded by users in trainer's python script for simplicity and demonstration purpose.",
-
     "dataFormat": "npy",
-
     "realm": "default/eu/uk",
-
     "isPublic": true
 }

--- a/examples/parallel_experiment/dataset_us_west.json
+++ b/examples/parallel_experiment/dataset_us_west.json
@@ -1,15 +1,9 @@
 {
     "name": "MNIST dataset",
-
     "description": "This dataset contains handwritten digits",
-
     "url": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist_4.npz",
-
     "//": "the url is a fake url, serving as a placeholder. Data-loading are hard-coded by users in trainer's python script for simplicity and demonstration purpose.",
-
     "dataFormat": "npy",
-
     "realm": "default/us/west",
-
     "isPublic": true
 }

--- a/examples/parallel_experiment/job.json
+++ b/examples/parallel_experiment/job.json
@@ -13,10 +13,7 @@
         ]
     },
     "priority": "low",
-
-    "backend": "mqtt",
     "maxRunTime": 1800,
-
     "baseModel": {
         "name": "",
         "version": 0
@@ -26,7 +23,7 @@
         "batchSize": 32,
         "learningRate": 0.01
     },
-    "dependencies" : [
+    "dependencies": [
         "numpy >= 1.2.0"
     ],
     "selector": {

--- a/examples/parallel_experiment/schema.json
+++ b/examples/parallel_experiment/schema.json
@@ -2,36 +2,53 @@
     "name": "A simple parallel experiment schema v1.0.0",
     "description": "The schema demonstrates a naive case of parallel experiment with three aggregators that are in Asia, Europe (EU) and North America (NA). Implemented with Keras",
     "roles": [
-	{
-	    "name": "trainer",
-	    "description": "It consumes the data and trains local model",
-	    "isDataConsumer": true
-	},
-	{
-	    "name": "aggregator",
-	    "description": "It aggregates the updates from trainers"
-	}
+        {
+            "name": "trainer",
+            "description": "It consumes the data and trains local model",
+            "isDataConsumer": true,
+            "groupAssociation": [
+                {
+                    "param-channel": "default/us"
+                }
+            ]
+        },
+        {
+            "name": "aggregator",
+            "description": "It aggregates the updates from trainers",
+            "replica": 1,
+            "groupAssociation": [
+                {
+                    "param-channel": "default/us"
+                }
+            ]
+        }
     ],
     "channels": [
-	{
-	    "name": "param-channel",
-	    "description": "Model update is sent from trainer to aggregator and vice-versa",
-	    "pair": [
-			"trainer",
-			"aggregator"
-	    ],
-	    "groupBy": {
-		"type": "tag",
-		"value": [
-		    "default/us",
-			"default/eu",
-			"default/asia"
-		]
-	    },
-	    "funcTags": {
-		"trainer": ["fetch", "upload"],
-		"aggregator": ["distribute", "aggregate"]
-	    }
-	}
+        {
+            "name": "param-channel",
+            "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "pair": [
+                "trainer",
+                "aggregator"
+            ],
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default/us",
+                    "default/eu",
+                    "default/asia"
+                ]
+            },
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
+            }
+        }
     ]
 }

--- a/examples/parallel_experiment/schema.json
+++ b/examples/parallel_experiment/schema.json
@@ -23,10 +23,12 @@
             ]
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "name": "param-channel",
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "pair": [
                 "trainer",
                 "aggregator"

--- a/lib/python/flame/examples/adult/aggregator/config.json
+++ b/lib/python/flame/examples/adult/aggregator/config.json
@@ -1,15 +1,16 @@
 {
     "taskid": "49d06b7526964db86cf37c70e8e0cdb6bd7aa742",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,9 +22,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "aggregator": ["distribute", "aggregate"],
-                "trainer": ["fetch", "upload"]
+            "funcTags": {
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
             }
         }
     ],
@@ -33,20 +40,22 @@
         "rounds": 5
     },
     "baseModel": {
-	"name": "",
-	"version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	"id": "622a358619ab59012eabeefb",
-	"name": "adult"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "adult"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+        "sort": "mlflow",
+        "uri": "http://flame-mlflow:5000"
     },
     "selector": {
-	"sort": "random",
-	"kwargs": {"k": 1}
+        "sort": "random",
+        "kwargs": {
+            "k": 1
+        }
     },
     "maxRunTime": 300,
     "realm": "",

--- a/lib/python/flame/examples/adult/trainer/config.json
+++ b/lib/python/flame/examples/adult/trainer/config.json
@@ -1,15 +1,16 @@
 {
     "taskid": "505f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,9 +22,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "aggregator": ["distribute", "aggregate"],
-                "trainer": ["fetch", "upload"]
+            "funcTags": {
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
             }
         }
     ],
@@ -37,20 +44,22 @@
         "rounds": 5
     },
     "baseModel": {
-	"name": "",
-	"version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	"id": "622a358619ab59012eabeefb",
-	"name": "adult"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "adult"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+        "sort": "mlflow",
+        "uri": "http://flame-mlflow:5000"
     },
     "selector": {
-	"sort": "random",
-	"kwargs": {"k": 1}
+        "sort": "random",
+        "kwargs": {
+            "k": 1
+        }
     },
     "maxRunTime": 300,
     "realm": "default/us/west",

--- a/lib/python/flame/examples/dist_mnist/trainer/config1.json
+++ b/lib/python/flame/examples/dist_mnist/trainer/config1.json
@@ -1,15 +1,16 @@
 {
     "taskid": "49d06b7526964db86cf37c70e8e0cdb6bd7aa746",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from a trainer to another trainer",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,8 +22,10 @@
                 "trainer",
                 "trainer"
             ],
-	    "funcTags": {
-                "trainer": ["ring_allreduce"]
+            "funcTags": {
+                "trainer": [
+                    "ring_allreduce"
+                ]
             }
         }
     ],
@@ -36,20 +39,20 @@
         "rounds": 10
     },
     "baseModel": {
-	    "name": "",
-	    "version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	    "id": "622a358619ab59012eabeefb",
-	    "name": "dist_mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "dist_mnist"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://mlflow.flame.test"
+        "sort": "mlflow",
+        "uri": "http://mlflow.flame.test"
     },
     "selector": {
-	    "sort": "default",
-	    "kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
         "sort": "fedavg",

--- a/lib/python/flame/examples/dist_mnist/trainer/config2.json
+++ b/lib/python/flame/examples/dist_mnist/trainer/config2.json
@@ -1,15 +1,16 @@
 {
     "taskid": "505f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from a trainer to another trainer",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,8 +22,10 @@
                 "trainer",
                 "trainer"
             ],
-	    "funcTags": {
-                "trainer": ["ring_allreduce"]
+            "funcTags": {
+                "trainer": [
+                    "ring_allreduce"
+                ]
             }
         }
     ],
@@ -36,20 +39,20 @@
         "rounds": 10
     },
     "baseModel": {
-	    "name": "",
-	    "version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	    "id": "622a358619ab59012eabeefb",
-	    "name": "dist_mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "dist_mnist"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://mlflow.flame.test"
+        "sort": "mlflow",
+        "uri": "http://mlflow.flame.test"
     },
     "selector": {
-	    "sort": "default",
-	    "kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
         "sort": "fedavg",

--- a/lib/python/flame/examples/dist_mnist/trainer/config3.json
+++ b/lib/python/flame/examples/dist_mnist/trainer/config3.json
@@ -1,15 +1,16 @@
 {
     "taskid": "f5a0b353dc3ca60d24174cbbbece3597c3287f3f",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from a trainer to another trainer",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,8 +22,10 @@
                 "trainer",
                 "trainer"
             ],
-	    "funcTags": {
-                "trainer": ["ring_allreduce"]
+            "funcTags": {
+                "trainer": [
+                    "ring_allreduce"
+                ]
             }
         }
     ],
@@ -36,20 +39,20 @@
         "rounds": 10
     },
     "baseModel": {
-	    "name": "",
-	    "version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	    "id": "622a358619ab59012eabeefb",
-	    "name": "dist_mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "dist_mnist"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://mlflow.flame.test"
+        "sort": "mlflow",
+        "uri": "http://mlflow.flame.test"
     },
     "selector": {
-	    "sort": "default",
-	    "kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
         "sort": "fedavg",

--- a/lib/python/flame/examples/hier_mnist/middle_aggregator/config_uk.json
+++ b/lib/python/flame/examples/hier_mnist/middle_aggregator/config_uk.json
@@ -1,15 +1,16 @@
 {
     "taskid": "49d06b7526964db86cf37c70e8e0cdb6bd7aa743",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from mid aggregator to global aggregator and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,28 +22,41 @@
                 "top-aggregator",
                 "middle-aggregator"
             ],
-	        "funcTags": {
-                "top-aggregator": ["distribute", "aggregate"],
-                "middle-aggregator": ["fetch", "upload"]
+            "funcTags": {
+                "top-aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "middle-aggregator": [
+                    "fetch",
+                    "upload"
+                ]
             }
         },
-		{
+        {
             "description": "Model update is sent from mid aggregator to trainer and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
-		    "default/us/west/org1",
-		    "default/uk/london/org2"
-		]
+                    "default/us/west/org1",
+                    "default/uk/london/org2"
+                ]
             },
             "name": "param-channel",
             "pair": [
                 "middle-aggregator",
                 "trainer"
             ],
-	        "funcTags": {
-                "middle-aggregator": ["distribute", "aggregate"],
-                "trainer": ["fetch", "upload"]
+            "funcTags": {
+                "middle-aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
             }
         }
     ],
@@ -56,20 +70,22 @@
         "rounds": 5
     },
     "baseModel": {
-	"name": "",
-	"version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	"id": "622a358619ab59012eabeefb",
-	"name": "mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "mnist"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+        "sort": "mlflow",
+        "uri": "http://flame-mlflow:5000"
     },
     "selector": {
-	"sort": "random",
-	"kwargs": {"k": 1}
+        "sort": "random",
+        "kwargs": {
+            "k": 1
+        }
     },
     "maxRunTime": 300,
     "realm": "default/uk/london/org2/flame",

--- a/lib/python/flame/examples/hier_mnist/middle_aggregator/config_us.json
+++ b/lib/python/flame/examples/hier_mnist/middle_aggregator/config_us.json
@@ -1,15 +1,16 @@
 {
     "taskid": "49d06b7526964db86cf37c70e8e0cdb6bd7aa744",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from mid aggregator to global aggregator and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -28,6 +29,7 @@
         },
 		{
             "description": "Model update is sent from mid aggregator to trainer and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [

--- a/lib/python/flame/examples/hier_mnist/top_aggregator/config.json
+++ b/lib/python/flame/examples/hier_mnist/top_aggregator/config.json
@@ -1,15 +1,16 @@
 {
     "taskid": "49d06b7526964db86cf37c70e8e0cdb6bd7aa742",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from mid aggregator to global aggregator and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,9 +22,15 @@
                 "top-aggregator",
                 "middle-aggregator"
             ],
-	        "funcTags": {
-                "top-aggregator": ["distribute", "aggregate"],
-                "middle-aggregator": ["fetch", "upload"]
+            "funcTags": {
+                "top-aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "middle-aggregator": [
+                    "fetch",
+                    "upload"
+                ]
             }
         }
     ],
@@ -37,20 +44,20 @@
         "rounds": 5
     },
     "baseModel": {
-	"name": "",
-	"version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	"id": "622a358619ab59012eabeefb",
-	"name": "mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "mnist"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+        "sort": "mlflow",
+        "uri": "http://flame-mlflow:5000"
     },
     "selector": {
-	"sort": "default",
-	"kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "maxRunTime": 300,
     "realm": "",

--- a/lib/python/flame/examples/hier_mnist/trainer/config_uk.json
+++ b/lib/python/flame/examples/hier_mnist/trainer/config_uk.json
@@ -1,30 +1,37 @@
 {
     "taskid": "49d06b7526964db86cf37c70e8e0cdb6bd7aa745",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
-		{
+        {
             "description": "Model update is sent from mid aggregator to trainer and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
-		    "default/us/west/org1",
-		    "default/uk/london/org2"
-				]
+                    "default/us/west/org1",
+                    "default/uk/london/org2"
+                ]
             },
             "name": "param-channel",
             "pair": [
                 "middle-aggregator",
                 "trainer"
             ],
-	        "funcTags": {
-                "middle-aggregator": ["distribute", "aggregate"],
-                "trainer": ["fetch", "upload"]
+            "funcTags": {
+                "middle-aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
             }
         }
     ],
@@ -38,20 +45,22 @@
         "rounds": 5
     },
     "baseModel": {
-	"name": "",
-	"version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	"id": "622a358619ab59012eabeefb",
-	"name": "mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "mnist"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+        "sort": "mlflow",
+        "uri": "http://flame-mlflow:5000"
     },
     "selector": {
-	"sort": "random",
-	"kwargs": {"k": 1}
+        "sort": "random",
+        "kwargs": {
+            "k": 1
+        }
     },
     "maxRunTime": 300,
     "realm": "default/uk/london/org2/machine1",

--- a/lib/python/flame/examples/hier_mnist/trainer/config_us.json
+++ b/lib/python/flame/examples/hier_mnist/trainer/config_us.json
@@ -1,30 +1,37 @@
 {
     "taskid": "49d06b7526964db86cf37c70e8e0cdb6bd7aa746",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
-		{
+        {
             "description": "Model update is sent from mid aggregator to trainer and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
-		    "default/us/west/org1",
-		    "default/uk/london/org2"
-		]
+                    "default/us/west/org1",
+                    "default/uk/london/org2"
+                ]
             },
             "name": "param-channel",
             "pair": [
                 "middle-aggregator",
                 "trainer"
             ],
-	        "funcTags": {
-                "middle-aggregator": ["distribute", "aggregate"],
-                "trainer": ["fetch", "upload"]
+            "funcTags": {
+                "middle-aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
             }
         }
     ],
@@ -38,20 +45,22 @@
         "rounds": 5
     },
     "baseModel": {
-	"name": "",
-	"version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	"id": "622a358619ab59012eabeefb",
-	"name": "mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "mnist"
     },
     "registry": {
-	"sort": "mlflow",
-	"uri": "http://flame-mlflow:5000"
+        "sort": "mlflow",
+        "uri": "http://flame-mlflow:5000"
     },
     "selector": {
-	"sort": "random",
-	"kwargs": {"k": 1}
+        "sort": "random",
+        "kwargs": {
+            "k": 1
+        }
     },
     "maxRunTime": 300,
     "realm": "default/us/west/org1/machine1",

--- a/lib/python/flame/examples/hybrid/aggregator/config.json
+++ b/lib/python/flame/examples/hybrid/aggregator/config.json
@@ -1,15 +1,16 @@
 {
     "taskid": "505f9fc483cf4df68a2409257b5fad7d3c580371",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from a trainer to an aggregator",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,9 +22,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "trainer": ["fetch", "upload"],
-                "aggregator": ["distribute", "aggregate"]
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
             }
         }
     ],
@@ -37,20 +44,20 @@
         "rounds": 5
     },
     "baseModel": {
-	    "name": "",
-	    "version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	    "id": "622a358619ab59012eabeefc",
-	    "name": "hybrid_mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefc",
+        "name": "hybrid_mnist"
     },
     "registry": {
-	    "sort": "dummy",
-	    "uri": ""
+        "sort": "dummy",
+        "uri": ""
     },
     "selector": {
-	    "sort": "default",
-	    "kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
         "sort": "fedavg",

--- a/lib/python/flame/examples/hybrid/trainer/config_eu_org1.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_eu_org1.json
@@ -1,15 +1,16 @@
 {
     "taskid": "205f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from a trainer to another trainer",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -22,12 +23,15 @@
                 "trainer",
                 "trainer"
             ],
-	    "funcTags": {
-                "trainer": ["ring_allreduce"]
+            "funcTags": {
+                "trainer": [
+                    "ring_allreduce"
+                ]
             }
         },
         {
             "description": "Model update is sent from a trainer to an aggregator",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -39,9 +43,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "trainer": ["fetch", "upload"],
-                "aggregator": ["distribute", "aggregate"]
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
             }
         }
     ],
@@ -55,20 +65,20 @@
         "rounds": 5
     },
     "baseModel": {
-	    "name": "",
-	    "version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	    "id": "622a358619ab59012eabeefc",
-	    "name": "hybrid_mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefc",
+        "name": "hybrid_mnist"
     },
     "registry": {
-	    "sort": "dummy",
-	    "uri": ""
+        "sort": "dummy",
+        "uri": ""
     },
     "selector": {
-	    "sort": "default",
-	    "kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
         "sort": "fedavg",

--- a/lib/python/flame/examples/hybrid/trainer/config_eu_org2.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_eu_org2.json
@@ -1,15 +1,16 @@
 {
     "taskid": "305f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from a trainer to another trainer",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -22,12 +23,15 @@
                 "trainer",
                 "trainer"
             ],
-	    "funcTags": {
-                "trainer": ["ring_allreduce"]
+            "funcTags": {
+                "trainer": [
+                    "ring_allreduce"
+                ]
             }
         },
         {
             "description": "Model update is sent from a trainer to an aggregator",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -39,9 +43,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "trainer": ["fetch", "upload"],
-                "aggregator": ["distribute", "aggregate"]
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
             }
         }
     ],
@@ -55,20 +65,20 @@
         "rounds": 5
     },
     "baseModel": {
-	    "name": "",
-	    "version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	    "id": "622a358619ab59012eabeefc",
-	    "name": "hybrid_mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefc",
+        "name": "hybrid_mnist"
     },
     "registry": {
-	    "sort": "dummy",
-	    "uri": ""
+        "sort": "dummy",
+        "uri": ""
     },
     "selector": {
-	    "sort": "default",
-	    "kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
         "sort": "fedavg",

--- a/lib/python/flame/examples/hybrid/trainer/config_us_org1.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_us_org1.json
@@ -1,15 +1,16 @@
 {
     "taskid": "405f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from a trainer to another trainer",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -22,12 +23,15 @@
                 "trainer",
                 "trainer"
             ],
-	    "funcTags": {
-                "trainer": ["ring_allreduce"]
+            "funcTags": {
+                "trainer": [
+                    "ring_allreduce"
+                ]
             }
         },
         {
             "description": "Model update is sent from a trainer to an aggregator",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -39,9 +43,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "trainer": ["fetch", "upload"],
-                "aggregator": ["distribute", "aggregate"]
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
             }
         }
     ],
@@ -55,20 +65,20 @@
         "rounds": 5
     },
     "baseModel": {
-	    "name": "",
-	    "version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	    "id": "622a358619ab59012eabeefc",
-	    "name": "hybrid_mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefc",
+        "name": "hybrid_mnist"
     },
     "registry": {
-	    "sort": "dummy",
-	    "uri": ""
+        "sort": "dummy",
+        "uri": ""
     },
     "selector": {
-	    "sort": "default",
-	    "kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
         "sort": "fedavg",

--- a/lib/python/flame/examples/hybrid/trainer/config_us_org2.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_us_org2.json
@@ -1,15 +1,16 @@
 {
     "taskid": "505f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "flame-mosquitto",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from a trainer to another trainer",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -22,12 +23,15 @@
                 "trainer",
                 "trainer"
             ],
-	    "funcTags": {
-                "trainer": ["ring_allreduce"]
+            "funcTags": {
+                "trainer": [
+                    "ring_allreduce"
+                ]
             }
         },
         {
             "description": "Model update is sent from a trainer to an aggregator",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -39,9 +43,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "trainer": ["fetch", "upload"],
-                "aggregator": ["distribute", "aggregate"]
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
             }
         }
     ],
@@ -55,20 +65,20 @@
         "rounds": 5
     },
     "baseModel": {
-	    "name": "",
-	    "version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	    "id": "622a358619ab59012eabeefc",
-	    "name": "hybrid_mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefc",
+        "name": "hybrid_mnist"
     },
     "registry": {
-	    "sort": "dummy",
-	    "uri": ""
+        "sort": "dummy",
+        "uri": ""
     },
     "selector": {
-	    "sort": "default",
-	    "kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
         "sort": "fedavg",

--- a/lib/python/flame/examples/medmnist/aggregator/config.json
+++ b/lib/python/flame/examples/medmnist/aggregator/config.json
@@ -1,15 +1,16 @@
 {
     "taskid": "49d06b7526964db86cf37c70e8e0cdb6bd7aa742",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "broker.hivemq.com",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,9 +22,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "aggregator": ["distribute", "aggregate"],
-                "trainer": ["fetch", "upload"]
+            "funcTags": {
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
             }
         }
     ],
@@ -35,27 +42,27 @@
         "batchSize": 32,
         "learningRate": 0.001,
         "rounds": 5,
-		"epochs": 2
+        "epochs": 2
     },
     "baseModel": {
-	"name": "",
-	"version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	"id": "622a358619ab59012eabeefb",
-	"name": "mednist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "mednist"
     },
     "registry": {
-	"sort": "dummy",
-	"uri": ""
+        "sort": "dummy",
+        "uri": ""
     },
     "selector": {
-	"sort": "default",
-	"kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
-    "sort": "fedavg",
-    "kwargs": {}
+        "sort": "fedavg",
+        "kwargs": {}
     },
     "maxRunTime": 300,
     "realm": "default",

--- a/lib/python/flame/examples/medmnist/trainer/config.json
+++ b/lib/python/flame/examples/medmnist/trainer/config.json
@@ -1,15 +1,16 @@
 {
     "taskid": "505f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "broker.hivemq.com",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,9 +22,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "aggregator": ["distribute", "aggregate"],
-                "trainer": ["fetch", "upload"]
+            "funcTags": {
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
             }
         }
     ],
@@ -35,27 +42,27 @@
         "batchSize": 32,
         "learningRate": 0.001,
         "rounds": 5,
-		"epochs": 2
+        "epochs": 2
     },
     "baseModel": {
-	"name": "",
-	"version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	"id": "622a358619ab59012eabeefb",
-	"name": "mednist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "mednist"
     },
     "registry": {
-	"sort": "dummy",
-	"uri": ""
+        "sort": "dummy",
+        "uri": ""
     },
     "selector": {
-	"sort": "default",
-	"kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
-    "sort": "fedavg",
-    "kwargs": {}
+        "sort": "fedavg",
+        "kwargs": {}
     },
     "maxRunTime": 300,
     "realm": "default",

--- a/lib/python/flame/examples/mnist/aggregator/config.json
+++ b/lib/python/flame/examples/mnist/aggregator/config.json
@@ -1,15 +1,16 @@
 {
     "taskid": "49d06b7526964db86cf37c70e8e0cdb6bd7aa742",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "broker.hivemq.com",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,9 +22,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "aggregator": ["distribute", "aggregate"],
-                "trainer": ["fetch", "upload"]
+            "funcTags": {
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
             }
         }
     ],
@@ -37,20 +44,20 @@
         "rounds": 5
     },
     "baseModel": {
-	    "name": "",
-	    "version": 2
+        "name": "",
+        "version": 2
     },
-    "job" : {
-	    "id": "622a358619ab59012eabeefb",
-	    "name": "mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "mnist"
     },
     "registry": {
-	    "sort": "dummy",
-	    "uri": ""
+        "sort": "dummy",
+        "uri": ""
     },
     "selector": {
-	    "sort": "default",
-	    "kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
         "sort": "fedavg",

--- a/lib/python/flame/examples/mnist/trainer/config.json
+++ b/lib/python/flame/examples/mnist/trainer/config.json
@@ -1,15 +1,16 @@
 {
     "taskid": "505f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "mqtt",
     "brokers": [
         {
             "host": "broker.hivemq.com",
             "sort": "mqtt"
         }
     ],
+    "defaultBackend": "mqtt",
     "channels": [
         {
             "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "backend": "mqtt",
             "groupBy": {
                 "type": "tag",
                 "value": [
@@ -21,9 +22,15 @@
                 "trainer",
                 "aggregator"
             ],
-	    "funcTags": {
-                "aggregator": ["distribute", "aggregate"],
-                "trainer": ["fetch", "upload"]
+            "funcTags": {
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
             }
         }
     ],
@@ -37,20 +44,20 @@
         "rounds": 5
     },
     "baseModel": {
-	    "name": "",
-	    "version": 1
+        "name": "",
+        "version": 1
     },
-    "job" : {
-	    "id": "622a358619ab59012eabeefb",
-	    "name": "mnist"
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "mnist"
     },
     "registry": {
-	    "sort": "dummy",
-	    "uri": ""
+        "sort": "dummy",
+        "uri": ""
     },
     "selector": {
-	    "sort": "default",
-	    "kwargs": {}
+        "sort": "default",
+        "kwargs": {}
     },
     "optimizer": {
         "sort": "fedavg",

--- a/pkg/openapi/model_channel_group_by.go
+++ b/pkg/openapi/model_channel_group_by.go
@@ -30,3 +30,30 @@ type ChannelGroupBy struct {
 
 	Value []string `json:"value"`
 }
+
+// AssertChannelGroupByRequired checks if the required fields are not zero-ed
+func AssertChannelGroupByRequired(obj ChannelGroupBy) error {
+	elements := map[string]interface{}{
+		"type":  obj.Type,
+		"value": obj.Value,
+	}
+	for name, el := range elements {
+		if isZero := IsZeroValue(el); isZero {
+			return &RequiredError{Field: name}
+		}
+	}
+
+	return nil
+}
+
+// AssertRecurseChannelGroupByRequired recursively checks if required fields are not zero-ed in a nested slice.
+// Accepts only nested slice of ChannelGroupBy (e.g. [][]ChannelGroupBy), otherwise ErrTypeAssertionError is thrown.
+func AssertRecurseChannelGroupByRequired(objSlice interface{}) error {
+	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
+		aChannelGroupBy, ok := obj.(ChannelGroupBy)
+		if !ok {
+			return ErrTypeAssertionError
+		}
+		return AssertChannelGroupByRequired(aChannelGroupBy)
+	})
+}

--- a/pkg/openapi/model_connector.go
+++ b/pkg/openapi/model_connector.go
@@ -32,3 +32,30 @@ type Connector struct {
 
 	Connection map[string]interface{} `json:"connection"`
 }
+
+// AssertConnectorRequired checks if the required fields are not zero-ed
+func AssertConnectorRequired(obj Connector) error {
+	elements := map[string]interface{}{
+		"name":       obj.Name,
+		"connection": obj.Connection,
+	}
+	for name, el := range elements {
+		if isZero := IsZeroValue(el); isZero {
+			return &RequiredError{Field: name}
+		}
+	}
+
+	return nil
+}
+
+// AssertRecurseConnectorRequired recursively checks if required fields are not zero-ed in a nested slice.
+// Accepts only nested slice of Connector (e.g. [][]Connector), otherwise ErrTypeAssertionError is thrown.
+func AssertRecurseConnectorRequired(objSlice interface{}) error {
+	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
+		aConnector, ok := obj.(Connector)
+		if !ok {
+			return ErrTypeAssertionError
+		}
+		return AssertConnectorRequired(aConnector)
+	})
+}

--- a/pkg/openapi/model_design_schema.go
+++ b/pkg/openapi/model_design_schema.go
@@ -38,4 +38,51 @@ type DesignSchema struct {
 	Channels []Channel `json:"channels"`
 
 	Connectors []Connector `json:"connectors,omitempty"`
+
+	DefaultBackend CommBackend `json:"defaultBackend"`
+}
+
+// AssertDesignSchemaRequired checks if the required fields are not zero-ed
+func AssertDesignSchemaRequired(obj DesignSchema) error {
+	elements := map[string]interface{}{
+		"version":        obj.Version,
+		"name":           obj.Name,
+		"roles":          obj.Roles,
+		"channels":       obj.Channels,
+		"defaultBackend": obj.DefaultBackend,
+	}
+	for name, el := range elements {
+		if isZero := IsZeroValue(el); isZero {
+			return &RequiredError{Field: name}
+		}
+	}
+
+	for _, el := range obj.Roles {
+		if err := AssertRoleRequired(el); err != nil {
+			return err
+		}
+	}
+	for _, el := range obj.Channels {
+		if err := AssertChannelRequired(el); err != nil {
+			return err
+		}
+	}
+	for _, el := range obj.Connectors {
+		if err := AssertConnectorRequired(el); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AssertRecurseDesignSchemaRequired recursively checks if required fields are not zero-ed in a nested slice.
+// Accepts only nested slice of DesignSchema (e.g. [][]DesignSchema), otherwise ErrTypeAssertionError is thrown.
+func AssertRecurseDesignSchemaRequired(objSlice interface{}) error {
+	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
+		aDesignSchema, ok := obj.(DesignSchema)
+		if !ok {
+			return ErrTypeAssertionError
+		}
+		return AssertDesignSchemaRequired(aDesignSchema)
+	})
 }

--- a/pkg/openapi/model_job_spec.go
+++ b/pkg/openapi/model_job_spec.go
@@ -45,8 +45,6 @@ type JobSpec struct {
 
 	Priority JobPriority `json:"priority,omitempty"`
 
-	Backend CommBackend `json:"backend,omitempty"`
-
 	MaxRunTime int32 `json:"maxRunTime,omitempty"`
 
 	BaseModel BaseModel `json:"baseModel,omitempty"`

--- a/pkg/openapi/model_role.go
+++ b/pkg/openapi/model_role.go
@@ -34,4 +34,32 @@ type Role struct {
 	IsDataConsumer bool `json:"isDataConsumer,omitempty"`
 
 	Replica int32 `json:"replica,omitempty"`
+
+	GroupAssociation []map[string]string `json:"groupAssociation,omitempty"`
+}
+
+// AssertRoleRequired checks if the required fields are not zero-ed
+func AssertRoleRequired(obj Role) error {
+	elements := map[string]interface{}{
+		"name": obj.Name,
+	}
+	for name, el := range elements {
+		if isZero := IsZeroValue(el); isZero {
+			return &RequiredError{Field: name}
+		}
+	}
+
+	return nil
+}
+
+// AssertRecurseRoleRequired recursively checks if required fields are not zero-ed in a nested slice.
+// Accepts only nested slice of Role (e.g. [][]Role), otherwise ErrTypeAssertionError is thrown.
+func AssertRecurseRoleRequired(objSlice interface{}) error {
+	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
+		aRole, ok := obj.(Role)
+		if !ok {
+			return ErrTypeAssertionError
+		}
+		return AssertRoleRequired(aRole)
+	})
 }

--- a/scripts/flameDiagnose.sh
+++ b/scripts/flameDiagnose.sh
@@ -1,0 +1,48 @@
+delimiter="----------"
+
+go version
+
+echo $delimiter
+
+echo "Python3:" $(python3 --version)
+echo "Pyenv:" $(pyenv version)
+
+echo $delimiter
+
+docker --version
+
+echo $delimiter
+
+minikube version
+
+echo $delimiter
+
+echo "kubectl:"
+kubectl version --short
+
+echo $delimiter
+
+echo "helm:"
+helm version
+
+echo $delimiter
+
+echo "jq:"
+jq --version
+
+echo $delimiter
+
+echo "DNS configuration:"
+cat /etc/resolver/flame-test
+
+echo $delimiter
+
+echo "minikube IP:"
+minikube ip
+
+echo $delimiter
+
+echo "flame pods:"
+kubectl get pods -n flame
+
+echo $delimiter


### PR DESCRIPTION
## Description

Until now we were configuring the job with the required backend protocol used to communicate.
Now we allow each channel to define it's own backend communication protocol. 
If no communication protocol it's specified then it will be used the one witch is default. The default communication protocol it's a new field defined at schema level and which it's mandatory to be specified.


## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
