### PR TITLE
fix: workaround for hybrid mode with two p2p backends

### DIFF
--- a/lib/python/flame/examples/hybrid/aggregator/config.json
+++ b/lib/python/flame/examples/hybrid/aggregator/config.json
@@ -1,6 +1,6 @@
 {
     "taskid": "505f9fc483cf4df68a2409257b5fad7d3c580371",
-    "backend": "p2p",
+    "backend": "mqtt",
     "brokers": [
         {
             "host": "localhost",

--- a/lib/python/flame/examples/hybrid/trainer/config_eu_org1.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_eu_org1.json
@@ -1,6 +1,6 @@
 {
     "taskid": "205f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "p2p",
+    "backend": "mqtt",
     "brokers": [
         {
             "host": "localhost",
@@ -96,7 +96,8 @@
             ]
         },
         "global-channel": {
-            "backend": "p2p",
+            "//": "bug: due to https://github.com/grpc/grpc/issues/25364, more than one p2p (grpc) backend can be used",
+            "backend": "mqtt",
             "brokers": [
                 {
                     "host": "localhost",

--- a/lib/python/flame/examples/hybrid/trainer/config_eu_org2.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_eu_org2.json
@@ -1,6 +1,6 @@
 {
     "taskid": "305f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "p2p",
+    "backend": "mqtt",
     "brokers": [
         {
             "host": "localhost",
@@ -96,7 +96,8 @@
             ]
         },
         "global-channel": {
-            "backend": "p2p",
+            "//": "bug: due to https://github.com/grpc/grpc/issues/25364, more than one p2p (grpc) backend can be used",
+            "backend": "mqtt",
             "brokers": [
                 {
                     "host": "localhost",

--- a/lib/python/flame/examples/hybrid/trainer/config_us_org1.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_us_org1.json
@@ -1,6 +1,6 @@
 {
     "taskid": "405f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "p2p",
+    "backend": "mqtt",
     "brokers": [
         {
             "host": "localhost",
@@ -96,7 +96,8 @@
             ]
         },
         "global-channel": {
-            "backend": "p2p",
+            "//": "bug: due to https://github.com/grpc/grpc/issues/25364, more than one p2p (grpc) backend can be used",
+            "backend": "mqtt",
             "brokers": [
                 {
                     "host": "localhost",

--- a/lib/python/flame/examples/hybrid/trainer/config_us_org2.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_us_org2.json
@@ -1,6 +1,6 @@
 {
     "taskid": "505f9fc483cf4df68a2409257b5fad7d3c580370",
-    "backend": "p2p",
+    "backend": "mqtt",
     "brokers": [
         {
             "host": "localhost",
@@ -96,7 +96,8 @@
             ]
         },
         "global-channel": {
-            "backend": "p2p",
+            "//": "bug: due to https://github.com/grpc/grpc/issues/25364, more than one p2p (grpc) backend can be used",
+            "backend": "mqtt",
             "brokers": [
                 {
                     "host": "localhost",


### PR DESCRIPTION
## Description

Due to https://github.com/grpc/grpc/issues/25364, when two p2p backends (which rely on grpc and asyncio) are defined, the hybrid mode example throws an execption: 'BlockingIOError: [Errno 35] Resource temporarily unavailable'. The issue still appears unresolved. As a temporary workaround, we use two different types of backends: mqtt for one and p2p for the other. This means that when this example is executed, both metaserver and a mqtt broker (e.g., mosquitto) must be running in the local machine.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
