### PR TITLE
gpu and cpu compatibility pytorch

### DIFF
--- a/lib/python/flame/common/constants.py
+++ b/lib/python/flame/common/constants.py
@@ -41,3 +41,9 @@ class CommType(Enum):
 
     BROADCAST = 1
     UNICAST = 2
+
+class DeviceType(Enum):
+    """Enum class for device."""
+
+    CPU = 1
+    GPU = 2

--- a/lib/python/flame/mode/distributed/trainer.py
+++ b/lib/python/flame/mode/distributed/trainer.py
@@ -24,7 +24,9 @@ from ...channel_manager import ChannelManager
 from ...common.custom_abcmeta import ABCMeta, abstract_attribute
 from ...common.util import (MLFramework, delta_weights_pytorch,
                             delta_weights_tensorflow, get_ml_framework_in_use,
-                            mlflow_runname, valid_frameworks)
+                            mlflow_runname, valid_frameworks,
+                            weights_to_device, weights_to_model_device)
+from ...common.constants import DeviceType
 from ...registries import registry_provider
 from ..composer import Composer
 from ..message import MessageType
@@ -42,6 +44,10 @@ class Trainer(Role, metaclass=ABCMeta):
     @abstract_attribute
     def config(self):
         """Abstract attribute for config object."""
+    
+    @abstract_attribute
+    def model(self):
+        """Abstract attribute for model object."""
 
     @abstract_attribute
     def dataset_size(self):
@@ -125,6 +131,9 @@ class Trainer(Role, metaclass=ABCMeta):
         # https://github.com/baidu-research/baidu-allreduce/blob/master/collectives.cu
         logger.info("starting ring-allreduce")
         my_id = channel.get_backend_id()
+        
+        # do all communication with weights on cpu
+        self.weights = weights_to_device(self.weights, DeviceType.CPU)
 
         rank = self.ends_of_ring.index(my_id)
         size = len(self.ends_of_ring)
@@ -206,6 +215,8 @@ class Trainer(Role, metaclass=ABCMeta):
             from_idx = chunk_ends[recv_chunk_idx] - chunk_sizes[recv_chunk_idx]
 
             self._allgather_fn(from_idx, recv_chunk)
+            
+        self.weights = weights_to_model_device(self.weights, self.model)
 
         # digest = hashlib.sha1(str(self.weights).encode('utf-8')).hexdigest()
         # logger.debug(f"after allgather: weight digest - {digest}")
@@ -316,7 +327,7 @@ class Trainer(Role, metaclass=ABCMeta):
                     MessageType.DATASET_SIZE: self.dataset_size,
                     MessageType.ROUND: self._round,
                     MessageType.IS_COMMITTER: self.is_committer,
-                    MessageType.RING_WEIGHTS: self.ring_weights
+                    MessageType.RING_WEIGHTS: weights_to_device(self.ring_weights, DeviceType.CPU)
                 }
                 channel.send(end, ring_weights_msg)
 
@@ -324,7 +335,7 @@ class Trainer(Role, metaclass=ABCMeta):
                 if MessageType.RING_WEIGHTS in msg:
                     # set latest weights sent from committer
                     logger.debug(f"{my_id}: fetching ring weights from {end}")
-                    self.weights = msg[MessageType.RING_WEIGHTS]
+                    self.weights = weights_to_model_device(msg[MessageType.RING_WEIGHTS], self.model)
                     self._update_model()
                 else:
                     # since ring weights are not in the message from committer,

--- a/lib/python/flame/mode/horizontal/asyncfl/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/asyncfl/top_aggregator.py
@@ -21,6 +21,8 @@ from copy import deepcopy
 
 from ....channel import VAL_CH_STATE_RECV, VAL_CH_STATE_SEND
 from ....optimizer.train_result import TrainResult
+from ....common.util import (weights_to_device, weights_to_model_device)
+from ....common.constants import DeviceType
 from ...composer import Composer
 from ...message import MessageType
 from ...tasklet import Loop, Tasklet
@@ -74,7 +76,7 @@ class TopAggregator(SyncTopAgg):
         logger.debug(f"received data from {end}")
 
         if MessageType.WEIGHTS in msg:
-            weights = msg[MessageType.WEIGHTS]
+            weights = weights_to_model_device(msg[MessageType.WEIGHTS], self.model)
 
         if MessageType.DATASET_SIZE in msg:
             count = msg[MessageType.DATASET_SIZE]
@@ -139,7 +141,7 @@ class TopAggregator(SyncTopAgg):
             # we use _round to indicate a model version
             channel.send(
                 end, {
-                    MessageType.WEIGHTS: self.weights,
+                    MessageType.WEIGHTS: weights_to_device(self.weights, DeviceType.CPU),
                     MessageType.ROUND: self._round,
                     MessageType.MODEL_VERSION: self._round
                 })

--- a/lib/python/flame/mode/horizontal/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/top_aggregator.py
@@ -24,7 +24,9 @@ from diskcache import Cache
 from ...channel_manager import ChannelManager
 from ...common.custom_abcmeta import ABCMeta, abstract_attribute
 from ...common.util import (MLFramework, get_ml_framework_in_use,
-                            mlflow_runname, valid_frameworks)
+                            mlflow_runname, valid_frameworks,
+                            weights_to_device, weights_to_model_device)
+from ...common.constants import DeviceType
 from ...optimizer.train_result import TrainResult
 from ...optimizers import optimizer_provider
 from ...plugin import PluginManager, PluginType
@@ -116,7 +118,7 @@ class TopAggregator(Role, metaclass=ABCMeta):
 
             logger.debug(f"received data from {end}")
             if MessageType.WEIGHTS in msg:
-                weights = msg[MessageType.WEIGHTS]
+                weights = weights_to_model_device(msg[MessageType.WEIGHTS], self.model)
 
             if MessageType.DATASET_SIZE in msg:
                 count = msg[MessageType.DATASET_SIZE]
@@ -166,7 +168,7 @@ class TopAggregator(Role, metaclass=ABCMeta):
         for end in channel.ends():
             logger.debug(f"sending weights to {end}")
             channel.send(end, {
-                MessageType.WEIGHTS: self.weights,
+                MessageType.WEIGHTS: weights_to_device(self.weights, DeviceType.CPU),
                 MessageType.ROUND: self._round
             })
 


### PR DESCRIPTION
This modification will allow trainers/aggregators to work on different devices across different machines.

All weights are communicated by placing them on the CPU before serializing them. Then, they are moved back to the device where they were previously.

An import error for fedprox was also fixed.
All trainers now require a self.model attribute, and all middle aggregators must only use the CPU (not enforced).