### PR TITLE
refactor+fix: configurable deployer / lib regularizer fix

### DIFF
--- a/cmd/deployer/cmd/root.go
+++ b/cmd/deployer/cmd/root.go
@@ -18,149 +18,89 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 
 	"github.com/cisco-open/flame/cmd/deployer/app"
+	"github.com/cisco-open/flame/cmd/deployer/config"
 	"github.com/cisco-open/flame/pkg/openapi"
 	"github.com/cisco-open/flame/pkg/util"
 )
 
 const (
-	argApiserver = "apiserver"
-	argNotifier  = "notifier"
-	argAdminId   = "adminid"
-	argRegion    = "region"
-	argComputeId = "computeid"
-	argApiKey    = "apikey"
-	argPlatform  = "platform"
-	argNamespace = "namespace"
-
 	optionInsecure = "insecure"
 	optionPlain    = "plain"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   util.Deployer,
-	Short: util.ProjectName + " Deployer",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		flags := cmd.Flags()
+var (
+	cfgFile string
+	cfg     *config.Config
 
-		apiserver, err := flags.GetString(argApiserver)
-		if err != nil {
-			return err
-		}
-		if len(strings.Split(apiserver, ":")) != util.NumTokensInRestEndpoint {
-			return fmt.Errorf("incorrect format for apiserver endpoint: %s", apiserver)
-		}
+	rootCmd = &cobra.Command{
+		Use:   util.Deployer,
+		Short: util.ProjectName + " Deployer",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
 
-		notifier, err := flags.GetString(argNotifier)
-		if err != nil {
-			return err
-		}
-		if len(strings.Split(notifier, ":")) != util.NumTokensInEndpoint {
-			return fmt.Errorf("incorrect format for notifier endpoint: %s", notifier)
-		}
+			bInsecure, _ := flags.GetBool(optionInsecure)
+			bPlain, _ := flags.GetBool(optionPlain)
 
-		adminId, err := flags.GetString(argAdminId)
-		if err != nil {
-			return err
-		}
+			if bInsecure && bPlain {
+				err := fmt.Errorf("options --%s and --%s are incompatible; enable one of them",
+					optionInsecure, optionPlain)
+				return err
+			}
 
-		region, err := flags.GetString(argRegion)
-		if err != nil {
-			return err
-		}
+			computeSpec := openapi.ComputeSpec{
+				AdminId:   cfg.AdminId,
+				Region:    cfg.Region,
+				ComputeId: cfg.ComputeId,
+				ApiKey:    cfg.Apikey,
+			}
 
-		computeId, err := flags.GetString(argComputeId)
-		if err != nil {
-			return err
-		}
+			compute, err := app.NewCompute(cfg.Apiserver, computeSpec, bInsecure, bPlain)
+			if err != nil {
+				return err
+			}
 
-		apikey, err := flags.GetString(argApiKey)
-		if err != nil {
-			return err
-		}
+			err = compute.RegisterNewCompute()
+			if err != nil {
+				err = fmt.Errorf("unable to register new compute with controller: %s", err)
+				return err
+			}
 
-		platform, err := flags.GetString(argPlatform)
-		if err != nil {
-			return err
-		}
+			resoureHandler := app.NewResourceHandler(cfg, computeSpec, bInsecure, bPlain)
+			resoureHandler.Start()
 
-		namespace, err := flags.GetString(argNamespace)
-		if err != nil {
-			return err
-		}
-
-		bInsecure, _ := flags.GetBool(optionInsecure)
-		bPlain, _ := flags.GetBool(optionPlain)
-
-		if bInsecure && bPlain {
-			err = fmt.Errorf("options --%s and --%s are incompatible; enable one of them", optionInsecure, optionPlain)
-			return err
-		}
-
-		computeSpec := openapi.ComputeSpec{
-			AdminId:   adminId,
-			Region:    region,
-			ComputeId: computeId,
-			ApiKey:    apikey,
-		}
-
-		compute, err := app.NewCompute(apiserver, computeSpec, bInsecure, bPlain)
-		if err != nil {
-			return err
-		}
-
-		err = compute.RegisterNewCompute()
-		if err != nil {
-			err = fmt.Errorf("unable to register new compute with controller: %s", err)
-			return err
-		}
-
-		resoureHandler := app.NewResourceHandler(apiserver, notifier, computeSpec, platform, namespace, bInsecure, bPlain)
-		resoureHandler.Start()
-
-		select {}
-	},
-}
+			select {}
+		},
+	}
+)
 
 func init() {
-	defaultApiServerEp := fmt.Sprintf("http://0.0.0.0:%d", util.ApiServerRestApiPort)
-	rootCmd.Flags().StringP(argApiserver, "a", defaultApiServerEp, "API server endpoint")
-	rootCmd.MarkFlagRequired(argApiserver)
+	cobra.OnInitialize(initConfig)
 
-	defaultNotifierEp := fmt.Sprintf("0.0.0.0:%d", util.NotifierGrpcPort)
-	rootCmd.Flags().StringP(argNotifier, "n", defaultNotifierEp, "Notifier endpoint")
-	rootCmd.MarkFlagRequired(argNotifier)
-
-	defaultAdminId := "admin"
-	rootCmd.Flags().StringP(argAdminId, "d", defaultAdminId, "unique admin id")
-	rootCmd.MarkFlagRequired(argAdminId)
-
-	defaultRegion := "region"
-	rootCmd.Flags().StringP(argRegion, "r", defaultRegion, "region name")
-	rootCmd.MarkFlagRequired(argRegion)
-
-	defaultComputeId := "compute"
-	rootCmd.Flags().StringP(argComputeId, "c", defaultComputeId, "unique compute id")
-	rootCmd.MarkFlagRequired(argComputeId)
-
-	defaultApiKey := "apiKey"
-	rootCmd.Flags().StringP(argApiKey, "k", defaultApiKey, "unique apikey")
-	rootCmd.MarkFlagRequired(argApiKey)
-
-	defaultPlatform := "k8s"
-	rootCmd.Flags().StringP(argPlatform, "p", defaultPlatform, "compute platform")
-	rootCmd.MarkFlagRequired(argPlatform)
-
-	defaultNamespace := "flame"
-	rootCmd.Flags().StringP(argNamespace, "s", defaultNamespace, "compute namespace")
-	rootCmd.MarkFlagRequired(argNamespace)
+	usage := "config file (default: /etc/flame/deployer.yaml)"
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", usage)
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 
 	rootCmd.PersistentFlags().Bool(optionInsecure, false, "Allow insecure connection")
 	rootCmd.PersistentFlags().Bool(optionPlain, false, "Allow unencrypted connection")
+}
+
+func initConfig() {
+	if cfgFile == "" {
+		cfgFile = filepath.Join("/etc/flame/deployer.yaml")
+	}
+
+	var err error
+
+	cfg, err = config.LoadConfig(cfgFile)
+	if err != nil {
+		zap.S().Fatalf("Failed to load config %s: %v", cfgFile, err)
+	}
 }
 
 func Execute() error {

--- a/cmd/deployer/config/config.go
+++ b/cmd/deployer/config/config.go
@@ -1,0 +1,62 @@
+// Copyright 2023 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Apiserver string `yaml:"apiserver"`
+	Notifier  string `yaml:"notifier"`
+	AdminId   string `yaml:"adminId"`
+	Region    string `yaml:"region"`
+	ComputeId string `yaml:"computeId"`
+	Apikey    string `yaml:"apikey"`
+	Platform  string `yaml:"platform"`
+	Namespace string `yaml:"namespace"`
+
+	JobTemplate JobTemplate `yaml:"jobTemplate"`
+}
+
+type JobTemplate struct {
+	Folder string `yaml:"folder"`
+	File   string `yaml:"file"`
+}
+
+var fs afero.Fs
+
+func init() {
+	fs = afero.NewOsFs()
+}
+
+func LoadConfig(configPath string) (*Config, error) {
+	data, err := afero.ReadFile(fs, configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &Config{}
+
+	err = yaml.Unmarshal(data, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}

--- a/fiab/flame.sh
+++ b/fiab/flame.sh
@@ -110,22 +110,26 @@ function post_start_config {
 
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 	os_id=$(grep '^ID=' /etc/os-release | sed 's/"//g' | cut -d= -f2)
-	case $os_id in
-	    "amzn")
-		echo "set flame.test domain with $minikube_ip in route 53"
-		;;
-	    *)
-		subnet=$(ip a show | grep br- | grep inet | awk '{print $2}')
-		resolver_file=/etc/systemd/network/minikube.network
-		echo "[Match]" | sudo tee $resolver_file > /dev/null
-		echo "Name=br*" | sudo tee -a $resolver_file > /dev/null
-		echo "[Network]" | sudo tee -a $resolver_file > /dev/null
-		echo "Address=$subnet" | sudo tee -a $resolver_file > /dev/null
-		echo "DNS=$minikube_ip" | sudo tee -a $resolver_file > /dev/null
-		echo "Domains=~flame.test" | sudo tee -a $resolver_file > /dev/null
-		sudo systemctl restart systemd-networkd
-		;;
-	esac
+        case $os_id in
+            "amzn")
+                echo "set flame.test domain with $minikube_ip in route 53"
+                ;;
+            *)
+                IFS=. read -r oc1 oc2 oc3 oc4 <<< $minikube_ip
+                subnet=$(ip a show | grep $oc1.$oc2.$oc3 | awk '{print $2}')
+                device=$(ip a show | grep -B 2 $oc1.$oc2.$oc3 | head -n 1 | cut -d':' -f 2)
+                device=${device## }
+
+                resolver_file=/etc/systemd/network/minikube.network
+                echo "[Match]" | sudo tee $resolver_file > /dev/null
+                echo "Name=$device" | sudo tee -a $resolver_file > /dev/null
+                echo "[Network]" | sudo tee -a $resolver_file > /dev/null
+                echo "Address=$subnet" | sudo tee -a $resolver_file > /dev/null
+                echo "DNS=$minikube_ip" | sudo tee -a $resolver_file > /dev/null
+                echo "Domains=~flame.test" | sudo tee -a $resolver_file > /dev/null
+                sudo systemctl restart systemd-networkd
+                ;;
+        esac
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         resolver_file=/etc/resolver/flame-test
         echo "domain flame.test" | sudo tee $resolver_file > /dev/null
@@ -184,17 +188,17 @@ function post_stop_cleanup {
     minikube_ip=$(minikube ip)
 
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	os_id=$(grep '^ID=' /etc/os-release | sed 's/"//g' | cut -d= -f2)
-	case $os_id in
-	    "amzn")
-		echo "remove flame.test domain from route 53"
-		;;
-	    *)
-		resolver_file=/etc/systemd/network/minikube.network
-		sudo rm -f $resolver_file
-		sudo systemctl restart systemd-networkd
-		;;
-	esac
+        os_id=$(grep '^ID=' /etc/os-release | sed 's/"//g' | cut -d= -f2)
+        case $os_id in
+            "amzn")
+                echo "remove flame.test domain from route 53"
+                ;;
+            *)
+                resolver_file=/etc/systemd/network/minikube.network
+                sudo rm -f $resolver_file
+                sudo systemctl restart systemd-networkd
+                ;;
+        esac
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         resolver_file=/etc/resolver/flame-test
         sudo rm -f $resolver_file

--- a/fiab/helm-chart/control/templates/deployer-configmap.yaml
+++ b/fiab/helm-chart/control/templates/deployer-configmap.yaml
@@ -1,0 +1,36 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-deployer-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  deployer.yaml: |
+    ---
+    apiserver: "https://{{ .Values.frontDoorUrl.apiserver }}:443"
+    notifier: "{{ .Values.frontDoorUrl.notifier }}:443"
+    adminId: {{ .Values.deployer.adminId }}
+    region: {{ .Values.deployer.region }}
+    computeId: {{ .Values.deployer.computeId }}
+    apikey: {{ .Values.deployer.apiKey }}
+    platform: {{ .Values.deployer.platform }}
+    namespace: {{ .Values.deployer.namespace }}
+    jobTemplate:
+      folder: {{ .Values.deployer.jobTemplate.folder }}
+      file: {{ .Values.deployer.jobTemplate.file }}

--- a/fiab/helm-chart/control/templates/deployer-default-deployment.yaml
+++ b/fiab/helm-chart/control/templates/deployer-default-deployment.yaml
@@ -32,22 +32,6 @@ spec:
     spec:
       containers:
         - args:
-          - --apiserver
-          - "https://{{ .Values.frontDoorUrl.apiserver }}:443"
-          - --notifier
-          - "{{ .Values.frontDoorUrl.notifier }}:443"
-          - --adminid
-          - {{ .Values.deployerDefault.adminId }}
-          - --region
-          - {{ .Values.deployerDefault.region }}
-          - --computeid
-          - {{ .Values.deployerDefault.computeId }}
-          - --apikey
-          - {{ .Values.deployerDefault.apiKey }}
-          - --platform
-          - {{ .Values.deployerDefault.platform }}
-          - --namespace
-          - {{ .Values.deployerDefault.namespace }}
           {{ if .Values.insecure }}
           - "--insecure"
           {{ end }}
@@ -56,11 +40,19 @@ spec:
           imagePullPolicy: IfNotPresent
           name: {{ .Release.Name }}-deployer-default
           volumeMounts:
-            - mountPath: /flame/template
+            - mountPath: /etc/flame/deployer.yaml
+              name: config-volume
+              subPath: deployer.yaml
+
+            - mountPath: {{ .Values.deployer.jobTemplate.folder }}
               name: job-template-volume
-      
+
       serviceAccountName: deployer
       volumes:
+        - name: config-volume
+          configMap:
+            name: {{ .Release.Name }}-deployer-configmap
+
         - name: job-template-volume
           configMap:
             name: {{ .Release.Name }}-deployer-job-configmap

--- a/fiab/helm-chart/control/values.yaml
+++ b/fiab/helm-chart/control/values.yaml
@@ -106,13 +106,19 @@ mlflow:
   s3EndpointUrl: http://minio.flame.test
   servicePort: "5000"
 
-deployerDefault:
+deployer:
   adminId: "admin-1"
   region: "default/us"
   computeId: "default"
   apiKey: "apiKey-default"
   platform: "k8s"
   namespace: "flame"
+  jobTemplate:
+    folder: /flame/template
+    # to use a different template file, put the file in the "job" folder
+    # use its file name as the value of key "file".
+    # also, update the name in the templates/deployer-job-configmap.yaml
+    file: job-agent.yaml.mustache
 
 servicePort:
   apiserver: "10100"

--- a/fiab/helm-chart/deployer/templates/deployer-compute1-deployment.yaml
+++ b/fiab/helm-chart/deployer/templates/deployer-compute1-deployment.yaml
@@ -32,22 +32,6 @@ spec:
     spec:
       containers:
         - args:
-          - --apiserver
-          - "https://{{ .Values.frontDoorUrl.apiserver }}:443"
-          - --notifier
-          - "{{ .Values.frontDoorUrl.notifier }}:443"
-          - --adminid
-          - {{ .Values.deployerCompute1.adminId }}
-          - --region
-          - {{ .Values.deployerCompute1.region }}
-          - --computeid
-          - {{ .Values.deployerCompute1.computeId }}
-          - --apikey
-          - {{ .Values.deployerCompute1.apiKey }}
-          - --platform
-          - {{ .Values.deployerCompute1.platform }}
-          - --namespace
-          - {{ .Values.deployerCompute1.namespace }}
           {{ if .Values.insecure }}
           - "--insecure"
           {{ end }}
@@ -56,11 +40,19 @@ spec:
           imagePullPolicy: IfNotPresent
           name: {{ .Release.Name }}-deployer-compute1
           volumeMounts:
-            - mountPath: /flame/template
+            - mountPath: /etc/flame/deployer.yaml
+              name: config-volume
+              subPath: deployer.yaml
+
+            - mountPath: {{ .Values.deployer.jobTemplate.folder }}
               name: job-template-volume
       
       serviceAccountName: deployer
       volumes:
+        - name: config-volume
+          configMap:
+            name: {{ .Release.Name }}-deployer-configmap
+
         - name: job-template-volume
           configMap:
             name: {{ .Release.Name }}-deployer-job-configmap

--- a/fiab/helm-chart/deployer/templates/deployer-configmap.yaml
+++ b/fiab/helm-chart/deployer/templates/deployer-configmap.yaml
@@ -1,0 +1,36 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-deployer-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  deployer.yaml: |
+    ---
+    apiserver: "https://{{ .Values.frontDoorUrl.apiserver }}:443"
+    notifier: "{{ .Values.frontDoorUrl.notifier }}:443"
+    adminId: {{ .Values.deployer.adminId }}
+    region: {{ .Values.deployer.region }}
+    computeId: {{ .Values.deployer.computeId }}
+    apikey: {{ .Values.deployer.apiKey }}
+    platform: {{ .Values.deployer.platform }}
+    namespace: {{ .Values.deployer.namespace }}
+    jobTemplate:
+      folder: {{ .Values.deployer.jobTemplate.folder }}
+      file: {{ .Values.deployer.jobTemplate.file }}

--- a/fiab/helm-chart/deployer/values.yaml
+++ b/fiab/helm-chart/deployer/values.yaml
@@ -32,13 +32,19 @@ mlflow:
   s3EndpointUrl: http://minio.flame.test    # TODO: fix s3 access id and key issue
   servicePort: "5000"
 
-deployerCompute1:
+deployer:
   adminId: "admin-2"
   region: "default/us/west"
   computeId: "compute-1"
   apiKey: "apiKey-1"
   platform: "k8s"
   namespace: "flame"
+  jobTemplate:
+    folder: /flame/template
+    # to use a different template file, put the file in the "job" folder
+    # use its file name as the value of key "file".
+    # also, update the name in the templates/deployer-job-configmap.yaml
+    file: job-agent.yaml.mustache
 
 servicePort:
   agent: "10103"

--- a/lib/python/flame/optimizer/regularizer/default.py
+++ b/lib/python/flame/optimizer/regularizer/default.py
@@ -25,7 +25,7 @@ class Regularizer:
     def __init__(self):
         """Initialize Regularizer instance."""
         pass
-    
+
     def get_term(self, **kwargs):
         """No regularizer term for dummy regularizer."""
         return 0.0

--- a/lib/python/flame/optimizer/regularizer/fedprox.py
+++ b/lib/python/flame/optimizer/regularizer/fedprox.py
@@ -15,7 +15,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """FedProx Regularizer."""
 import logging
-from .regularizer import Regularizer
+
+from .default import Regularizer
 
 logger = logging.getLogger(__name__)
 
@@ -27,13 +28,13 @@ class FedProxRegularizer(Regularizer):
         """Initialize FedProxRegularizer instance."""
         super().__init__()
         self.mu = mu
-    
+
     def get_term(self, **kwargs):
-        """Calculate proximal term for client-side regularization"""
+        """Calculate proximal term for client-side regularization."""
         import torch
         w = kwargs['w']
         w_t = kwargs['w_t']
         norm_sq = 0.0
         for loc_param, glob_param in zip(w, w_t):
-            norm_sq += torch.sum(torch.pow(loc_param-glob_param, 2))
-        return (self.mu/2) * norm_sq
+            norm_sq += torch.sum(torch.pow(loc_param - glob_param, 2))
+        return (self.mu / 2) * norm_sq


### PR DESCRIPTION
## Description

deployer's job template file is hard-coded, which makes it hard to use different template file at deployment time. Using different different template file is useful when underlying infrastructure is different (e.g., k8s vs knative). To support that, template folder and file is fed as config variables.

Also, deployer's config info is fed as command argument, which is cumbersome. So, the config parsing part is refactored such that the info is fed as a configuration file.

During the testing of deployer change, a bug in the library is identified. The fix for it is added here too.

Finally, the local dns configuration in flame.sh is updated so that it can be done correctly across different linux distributions (e.g., archlinux and ubuntu). The tests for flame.sh are under archlinux and ubuntu.
## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
