### PR TITLE
fix: out of order message delivery

### DIFF
--- a/lib/python/flame/backend/chunk_manager.py
+++ b/lib/python/flame/backend/chunk_manager.py
@@ -1,0 +1,115 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Chunk Manager."""
+
+import logging
+from queue import Queue
+from threading import Thread
+
+from ..channel import Channel
+from ..common.util import run_async
+from ..proto import backend_msg_pb2 as msg_pb2
+from .chunk_store import ChunkStore
+
+logger = logging.getLogger(__name__)
+
+KEY_CHANNEL = "channel"
+KEY_LOOP = "loop"
+
+
+class ChunkThread(Thread):
+    """ChunkThread class."""
+
+    def __init__(self,
+                 group=None,
+                 target=None,
+                 name=None,
+                 args=(),
+                 kwargs=None,
+                 *,
+                 daemon=None):
+        """Initialize an instance."""
+        # call parent constructure method
+        super().__init__(group, target, name, daemon=daemon)
+
+        self._loop = kwargs[KEY_LOOP]
+        self._channel = kwargs[KEY_CHANNEL]
+
+        self.queue = Queue()
+        self.chunk_store = ChunkStore()
+
+    def insert(self, msg: msg_pb2.Data) -> None:
+        """Put a message into queue in the chunk thread."""
+        self.queue.put(msg)
+
+    def run(self):
+        """Override run function of Thread.
+
+        The function assembles chunks into a full-size message and passes
+        the message to its designated receive queue.
+        """
+
+        async def inner(end_id: str, data: bytes):
+            logger.debug(f'fully assembled data size = {len(data)}')
+
+            rxq = self._channel.get_rxq(end_id)
+            if rxq is None:
+                logger.debug(f"rxq not found for {end_id}")
+                return
+
+            await rxq.put(data)
+
+        while True:
+            msg = self.queue.get()
+
+            # assemble is done in a chunk thread so that it won't block
+            # asyncio task
+            status = self.chunk_store.assemble(msg)
+            if not status:
+                # reset chunk_store if message is wrong
+                self.chunk_store.reset()
+            else:
+                if not self.chunk_store.eom:
+                    # not an end of message, hence, can't get a payload
+                    # out of chunk store yet
+                    continue
+
+                payload = self.chunk_store.get_data()
+                # now push payload to a target receive queue.
+                _, status = run_async(inner(msg.end_id, payload), self._loop)
+
+                # message was completely assembled, reset the chunk store
+                self.chunk_store.reset()
+
+
+class ChunkManager(object):
+    """ChunkStore class."""
+
+    def __init__(self, loop):
+        """Initialize an instance."""
+        self._loop = loop
+        self._chunk_threads: dict[str, ChunkThread] = {}
+
+    def handle(self, msg: msg_pb2.Data, channel: Channel) -> None:
+        """Process msg."""
+        if msg.end_id not in self._chunk_threads:
+            kwargs = {KEY_LOOP: self._loop, KEY_CHANNEL: channel}
+            chunk_thd = ChunkThread(kwargs=kwargs, daemon=True)
+            self._chunk_threads[msg.end_id] = chunk_thd
+            chunk_thd.start()
+
+        chunk_thd = self._chunk_threads[msg.end_id]
+        chunk_thd.insert(msg)

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='flame',
-    version='0.0.16',
+    version='0.0.17',
     author='Flame Maintainers',
     author_email='flame-github-owners@cisco.com',
     include_package_data=True,


### PR DESCRIPTION
## Description

In order to minimize the blocking of asynchronous I/O tasks when a large number of message chunks (e.g., model size is large) need to be assembled, threading is used. This led to a bug wherein messages are delivered to a receive queue in an out-of-order fashion. For example, consider two back-to-back messages; the first message is larger than the second. In this case, the second can be inserted before the first because the second has high chance to finish the assembling.

The changes here are for fixing the bug. To do so, we leverage another queue to synchronize message delivery order. For that, chunk manager class is introduced. One chunk manager is created for a backend. And it maintains a list of chunk threads per end, each of which is responsible for assemling messages sequentially and pushing them into the receive queue of the end.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
