### PR TITLE
Make SDK config backwards compatible

### DIFF
--- a/lib/python/flame/config.py
+++ b/lib/python/flame/config.py
@@ -16,8 +16,8 @@
 """Config parser."""
 
 from enum import Enum
-from pydantic import Field
 import typing as t
+from pydantic import Field
 from pydantic import BaseModel as pydBaseModel
 import json
 
@@ -53,6 +53,10 @@ class OptimizerType(str, Enum):
     FEDADAGRAD = "fedadagrad"
     FEDADAM = "fedadam"
     FEDYOGI = "fedyogi"
+    # FedBuff from https://arxiv.org/pdf/1903.03934.pdf and
+    # https://arxiv.org/pdf/2111.04877.pdf
+    FEDBUFF = "fedbuff"
+    FEDPROX = "fedprox" # FedProx
 
     DEFAULT = FEDAVG
 
@@ -62,6 +66,7 @@ class SelectorType(str, Enum):
 
     DEFAULT = "default"
     RANDOM = "random"
+    FEDBUFF = "fedbuff"
 
 
 class Job(FlameSchema):
@@ -78,7 +83,7 @@ class Selector(FlameSchema):
     sort: SelectorType = Field(default=SelectorType.DEFAULT)
     kwargs: dict = Field(default={})
 
-
+    
 class Optimizer(FlameSchema):
     sort: OptimizerType = Field(default=OptimizerType.DEFAULT)
     kwargs: dict = Field(default={})
@@ -94,6 +99,7 @@ class Hyperparameters(FlameSchema):
     learning_rate: t.Optional[float] = Field(alias="learningRate")
     rounds: int
     epochs: int
+    aggregation_goal: t.Optional[int] = Field(alias="aggGoal", default=None)
 
 
 class Groups(FlameSchema):
@@ -145,6 +151,12 @@ class ChannelConfigs(FlameSchema):
 
 
 class Config(FlameSchema):
+    def __init__(self, config_path: str):
+        raw_config = read_config(config_path)
+        transformed_config = transform_config(raw_config)
+
+        super().__init__(**transformed_config)
+
     role: str
     realm: str
     task: t.Optional[str] = Field(default="local")
@@ -171,8 +183,7 @@ def read_config(filename: str) -> dict:
         return json.loads(f.read())
 
 
-def load_config(filename: str) -> Config:
-    raw_config = read_config(filename)
+def transform_config(raw_config: dict) -> dict:
     config_data = {
         "role": raw_config["role"],
         "realm": raw_config["realm"],
@@ -218,8 +229,8 @@ def load_config(filename: str) -> Config:
         "base_model": raw_config.get("baseModel", None),
         "dependencies": raw_config.get("dependencies", None),
     }
-    
-    return Config(**config_data)
+
+    return config_data
 
 
 def transform_channel(raw_channel_config: dict):

--- a/lib/python/flame/examples/adult/aggregator/main.py
+++ b/lib/python/flame/examples/adult/aggregator/main.py
@@ -19,7 +19,7 @@ import logging
 
 import torch
 import torch.nn as nn
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.mode.horizontal.top_aggregator import TopAggregator
 
 logger = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     t = PyTorchAdultAggregator(config)
     t.compose()

--- a/lib/python/flame/examples/adult/trainer/main.py
+++ b/lib/python/flame/examples/adult/trainer/main.py
@@ -24,7 +24,7 @@ import torch.nn as nn
 import torch.optim as optim
 from flame.common.constants import DATA_FOLDER_PATH
 from flame.common.util import install_packages
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.mode.horizontal.trainer import Trainer
 
 install_packages(['scikit-learn'])
@@ -149,7 +149,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     t = PyTorchAdultTrainer(config)
     t.compose()

--- a/lib/python/flame/examples/dist_mnist/trainer/keras/main.py
+++ b/lib/python/flame/examples/dist_mnist/trainer/keras/main.py
@@ -21,7 +21,7 @@ from random import randrange
 from statistics import mean
 
 import numpy as np
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.mode.distributed.trainer import Trainer
 from tensorflow import keras
 from tensorflow.keras import layers
@@ -132,7 +132,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     t = KerasMnistTrainer(config)
     t.compose()

--- a/lib/python/flame/examples/dist_mnist/trainer/pytorch/main.py
+++ b/lib/python/flame/examples/dist_mnist/trainer/pytorch/main.py
@@ -26,7 +26,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import torch.utils.data as data_utils
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.mode.distributed.trainer import Trainer
 from torchvision import datasets, transforms
 
@@ -145,7 +145,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     t = PyTorchMnistTrainer(config)
     t.compose()

--- a/lib/python/flame/examples/hier_mnist/middle_aggregator/main.py
+++ b/lib/python/flame/examples/hier_mnist/middle_aggregator/main.py
@@ -17,7 +17,7 @@
 
 import logging
 
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.mode.horizontal.middle_aggregator import MiddleAggregator
 # the following needs to be imported to let the flame know
 # this aggregator works on tensorflow model
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     a = KerasMnistMiddleAggregator(config)
     a.compose()

--- a/lib/python/flame/examples/hier_mnist/top_aggregator/main.py
+++ b/lib/python/flame/examples/hier_mnist/top_aggregator/main.py
@@ -17,7 +17,7 @@
 
 import logging
 
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.dataset import Dataset
 from flame.mode.horizontal.top_aggregator import TopAggregator
 from tensorflow import keras
@@ -82,7 +82,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     a = KerasMnistTopAggregator(config)
     a.compose()

--- a/lib/python/flame/examples/hier_mnist/trainer/main.py
+++ b/lib/python/flame/examples/hier_mnist/trainer/main.py
@@ -20,7 +20,7 @@ from random import randrange
 from statistics import mean
 
 import numpy as np
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.mode.horizontal.trainer import Trainer
 from tensorflow import keras
 from tensorflow.keras import layers
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     t = KerasMnistTrainer(config)
     t.compose()

--- a/lib/python/flame/examples/hybrid/aggregator/main.py
+++ b/lib/python/flame/examples/hybrid/aggregator/main.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.dataset import Dataset
 from flame.mode.horizontal.top_aggregator import TopAggregator
 from tensorflow import keras
@@ -81,7 +81,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     a = KerasMnistAggregator(config)
     a.compose()

--- a/lib/python/flame/examples/hybrid/trainer/main.py
+++ b/lib/python/flame/examples/hybrid/trainer/main.py
@@ -20,7 +20,7 @@ from random import randrange
 from statistics import mean
 
 import numpy as np
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.mode.hybrid.trainer import Trainer
 from tensorflow import keras
 from tensorflow.keras import layers
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     t = KerasMnistTrainer(config)
     t.compose()

--- a/lib/python/flame/examples/medmnist/aggregator/main.py
+++ b/lib/python/flame/examples/medmnist/aggregator/main.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.dataset import Dataset # Not sure why we need this.
 from flame.mode.horizontal.top_aggregator import TopAggregator
 import torch
@@ -85,7 +85,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     a = PyTorchMedMNistAggregator(config)
     a.compose()

--- a/lib/python/flame/examples/medmnist/trainer/main.py
+++ b/lib/python/flame/examples/medmnist/trainer/main.py
@@ -20,7 +20,7 @@ import logging
 from flame.common.util import install_packages
 install_packages(['scikit-learn'])
 
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.mode.horizontal.trainer import Trainer
 import torch
 import torchvision
@@ -212,7 +212,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     t = PyTorchMedMNistTrainer(config)
     t.compose()

--- a/lib/python/flame/examples/mnist/aggregator/keras/main.py
+++ b/lib/python/flame/examples/mnist/aggregator/keras/main.py
@@ -17,7 +17,7 @@
 
 import logging
 
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.dataset import Dataset
 from flame.mode.horizontal.top_aggregator import TopAggregator
 from tensorflow import keras
@@ -82,7 +82,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     a = KerasMnistAggregator(config)
     a.compose()

--- a/lib/python/flame/examples/mnist/aggregator/pytorch/main.py
+++ b/lib/python/flame/examples/mnist/aggregator/pytorch/main.py
@@ -24,7 +24,7 @@ import logging
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.dataset import Dataset
 from flame.mode.horizontal.top_aggregator import TopAggregator
 from torchvision import datasets, transforms
@@ -143,7 +143,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     a = PyTorchMnistAggregator(config)
     a.compose()

--- a/lib/python/flame/examples/mnist/trainer/keras/main.py
+++ b/lib/python/flame/examples/mnist/trainer/keras/main.py
@@ -20,7 +20,7 @@ from random import randrange
 from statistics import mean
 
 import numpy as np
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.mode.horizontal.trainer import Trainer
 from tensorflow import keras
 from tensorflow.keras import layers
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = load_config(args.config)
+    config = Config(args.config)
 
     t = KerasMnistTrainer(config)
     t.compose()

--- a/lib/python/flame/examples/mnist/trainer/pytorch/main.py
+++ b/lib/python/flame/examples/mnist/trainer/pytorch/main.py
@@ -26,7 +26,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import torch.utils.data as data_utils
-from flame.config import Config, load_config
+from flame.config import Config
 from flame.mode.horizontal.trainer import Trainer
 
 
@@ -146,7 +146,7 @@ if __name__ == "__main__":
     parser.add_argument('config', nargs='?', default="./config.json")
 
     args = parser.parse_args()
-    config = load_config(args.config)
+    config = Config(args.config)
 
     t = PyTorchMnistTrainer(config)
     t.compose()


### PR DESCRIPTION
## Description
This PR brings backwards compatibility for old SDK versions.
SDK config handling was changed in https://github.com/cisco-open/flame/pull/332 which introduced a breaking change since the way config loaded has changed. This PR addresses that and "reverts" the way config is loaded back to the old way, while retaining all the benefits of pydantic.

This backwards compatibility issue was raised during testing when we figured out that the zipped examples contained old sdk config loading which did not work with SDK v0.1.0.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
