### PR TITLE
build: use the flame version for which the code was released for

### DIFF
--- a/docs/03-b-amzn2-gpu.md
+++ b/docs/03-b-amzn2-gpu.md
@@ -231,7 +231,7 @@ Error: INSTALLATION FAILED: failed post-install: timed out waiting for the condi
 This issue may be because container images are large or the Internet connection is slow.
 The issue has been reported in minikube [github](https://github.com/kubernetes/minikube/issues/14789).
 The latest minikube still doesn't contain the patched component (cri-dockerd 0.2.6).
-A workaround is to pull images manually (e.g. `minikube ssh docker pull ciscoresearch/flame:latest`).
+A workaround is to pull images manually (e.g. `minikube ssh docker pull ciscoresearch/flame:v0.2.2`).
 The command `kubectl get pods -n flame` gives a list of pods and their status.
 The pods with `ErrImagePull` or `ImagePullBackOff` status are ones that might be affected by the issue.
 Identifying the required image can be done by running a `kubectl describe` command

--- a/docs/03-c-mac.md
+++ b/docs/03-c-mac.md
@@ -181,7 +181,7 @@ Error: INSTALLATION FAILED: failed post-install: timed out waiting for the condi
 This issue may be because container images are large or the Internet connection is slow.
 The issue has been reported in minikube [github](https://github.com/kubernetes/minikube/issues/14789).
 The latest minikube still doesn't contain the patched component (cri-dockerd 0.2.6).
-A workaround is to pull images manually (e.g. `minikube ssh docker pull ciscoresearch/flame:latest`).
+A workaround is to pull images manually (e.g. `minikube ssh docker pull ciscoresearch/flame:v0.2.2`).
 The command `kubectl get pods -n flame` gives a list of pods and their status.
 The pods with `ErrImagePull` or `ImagePullBackOff` status are ones that might be affected by the issue.
 Identifying the required image can be done by running a `kubectl describe` command

--- a/fiab/helm-chart/control/values.yaml
+++ b/fiab/helm-chart/control/values.yaml
@@ -64,9 +64,9 @@ minio:
       - minio.flame.test
 
 imageName: ciscoresearch/flame
-imageTag: latest
+imageTag: v0.2.2
 workerImageName: ciscoresearch/flame
-workerImageTag: latest
+workerImageTag: v0.2.2
 
 broker:
   - sort: mqtt

--- a/fiab/helm-chart/deployer/values.yaml
+++ b/fiab/helm-chart/deployer/values.yaml
@@ -22,7 +22,7 @@ minio:
       policy: readwrite
 
 imageName: ciscoresearch/flame
-imageTag: latest
+imageTag: v0.2.2
 
 frontDoorUrl:
   apiserver: apiserver.flame.test      # apiserver url needs to be updated


### PR DESCRIPTION
This is useful to avoid future issues in case we release new versions, but the local flame code/cluster is not upgraded to use the latest released code.

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
