### PR TITLE
update for Oort: overcommitment support

### DIFF
--- a/lib/python/flame/examples/oort_mnist/trainer/main.py
+++ b/lib/python/flame/examples/oort_mnist/trainer/main.py
@@ -20,7 +20,6 @@ https://github.com/pytorch/examples/blob/master/mnist/main.py.
 """
 
 import logging
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -114,7 +113,7 @@ class PyTorchOortMnistTrainer(Trainer):
 
     def _train_epoch(self, epoch):
         self.model.train()
-        self.set_stat_utility(0)
+        self.reset_stat_utility()
 
         # calculate trainer's statistical utility while running minibatches on epoch 1
         # this implementation was based on the Oort authors' implementation:

--- a/lib/python/flame/mode/horizontal/oort/trainer.py
+++ b/lib/python/flame/mode/horizontal/oort/trainer.py
@@ -103,13 +103,9 @@ class Trainer(BaseTrainer):
         else:
             return
 
-    def set_stat_utility(self, value: float) -> None:
-        """Set a new value to the trainer's statistical utility."""
-        self._stat_utility = value
-
-    def get_stat_utility(self) -> float:
-        """Get a value of the trainer's statistical utility."""
-        return self._stat_utility
+    def reset_stat_utility(self) -> None:
+        """Reset the trainer's statistical utility to zero."""
+        self._stat_utility = 0
 
     def compose(self) -> None:
         """Compose role with tasklets."""


### PR DESCRIPTION
The Oort algorithm performs overcommitment in trainer selection, that it selects 1.3 * K trainers at a round where K is the desired number of trainers. At the aggregation phase, the algorithm only accepts K trainers' model update in order of the arrival.

Implement the above functionality by replacing self.tmpq with self._rx_queue at channel.py in python library, which consistently gets input from end.get(). Also, channel.py now has self._active_recv_fifo_tasks, which maintains the ids of ends which are called for recv_fifo but are not finished with receiving the message.

Minor update: to comply with other functions that control trainer's utility, update lib/python/flame/examples/oort_mnist/trainer/main.py to use reset_stat_utility function instead of set_stat_utility function to make it zero at the beginning of each round

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
