### PR TITLE
update for Oort: accurate calculation of round duration with timestamp

### DIFF
--- a/lib/python/flame/mode/horizontal/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/top_aggregator.py
@@ -23,9 +23,14 @@ from diskcache import Cache
 
 from ...channel_manager import ChannelManager
 from ...common.custom_abcmeta import ABCMeta, abstract_attribute
-from ...common.util import (MLFramework, get_ml_framework_in_use,
-                            mlflow_runname, valid_frameworks,
-                            weights_to_device, weights_to_model_device)
+from ...common.util import (
+    MLFramework,
+    get_ml_framework_in_use,
+    mlflow_runname,
+    valid_frameworks,
+    weights_to_device,
+    weights_to_model_device,
+)
 from ...common.constants import DeviceType
 from ...optimizer.train_result import TrainResult
 from ...optimizers import optimizer_provider
@@ -39,8 +44,8 @@ from ...config import Config
 
 logger = logging.getLogger(__name__)
 
-TAG_DISTRIBUTE = 'distribute'
-TAG_AGGREGATE = 'aggregate'
+TAG_DISTRIBUTE = "distribute"
+TAG_AGGREGATE = "aggregate"
 
 
 class TopAggregator(Role, metaclass=ABCMeta):
@@ -78,15 +83,17 @@ class TopAggregator(Role, metaclass=ABCMeta):
         base_model = self.config.base_model
         if base_model and base_model.name != "" and base_model.version > 0:
             self.model = self.registry_client.load_model(
-                base_model.name, base_model.version)
+                base_model.name, base_model.version
+            )
 
         self.registry_client.setup_run(mlflow_runname(self.config))
         self.metrics = dict()
 
         # disk cache is used for saving memory in case model is large
         self.cache = Cache()
-        self.optimizer = optimizer_provider.get(self.config.optimizer.sort,
-                                                **self.config.optimizer.kwargs)
+        self.optimizer = optimizer_provider.get(
+            self.config.optimizer.sort, **self.config.optimizer.kwargs
+        )
 
         self._round = 1
         self._rounds = 1
@@ -97,7 +104,8 @@ class TopAggregator(Role, metaclass=ABCMeta):
         if self.framework == MLFramework.UNKNOWN:
             raise NotImplementedError(
                 "supported ml framework not found; "
-                f"supported frameworks are: {valid_frameworks}")
+                f"supported frameworks are: {valid_frameworks}"
+            )
 
     def get(self, tag: str) -> None:
         """Get data from remote role(s)."""
@@ -111,7 +119,8 @@ class TopAggregator(Role, metaclass=ABCMeta):
 
         total = 0
         # receive local model parameters from trainers
-        for end, msg in channel.recv_fifo(channel.ends()):
+        for msg, metadata in channel.recv_fifo(channel.ends()):
+            end, _ = metadata
             if not msg:
                 logger.debug(f"No data from {end}; skipping it")
                 continue
@@ -168,10 +177,15 @@ class TopAggregator(Role, metaclass=ABCMeta):
         # send out global model parameters to trainers
         for end in channel.ends():
             logger.debug(f"sending weights to {end}")
-            channel.send(end, {
-                MessageType.WEIGHTS: weights_to_device(self.weights, DeviceType.CPU),
-                MessageType.ROUND: self._round
-            })
+            channel.send(
+                end,
+                {
+                    MessageType.WEIGHTS: weights_to_device(
+                        self.weights, DeviceType.CPU
+                    ),
+                    MessageType.ROUND: self._round,
+                },
+            )
 
     def inform_end_of_training(self) -> None:
         """Inform all the trainers that the training is finished."""
@@ -209,7 +223,7 @@ class TopAggregator(Role, metaclass=ABCMeta):
         logger.debug(f"Incrementing current round: {self._round}")
         logger.debug(f"Total rounds: {self._rounds}")
         self._round += 1
-        self._work_done = (self._round > self._rounds)
+        self._work_done = self._round > self._rounds
 
         channel = self.cm.get_by_tag(self.dist_tag)
         if not channel:
@@ -280,10 +294,23 @@ class TopAggregator(Role, metaclass=ABCMeta):
 
         # create a loop object with loop exit condition function
         loop = Loop(loop_check_fn=lambda: self._work_done)
-        task_internal_init >> task_load_data >> task_init >> loop(
-            task_put >> task_get >> task_train >> task_eval >> task_analysis >>
-            task_save_metrics >> task_increment_round
-        ) >> task_end_of_training >> task_save_params >> task_save_model
+        (
+            task_internal_init
+            >> task_load_data
+            >> task_init
+            >> loop(
+                task_put
+                >> task_get
+                >> task_train
+                >> task_eval
+                >> task_analysis
+                >> task_save_metrics
+                >> task_increment_round
+            )
+            >> task_end_of_training
+            >> task_save_params
+            >> task_save_model
+        )
 
     def run(self) -> None:
         """Run role."""

--- a/lib/python/flame/mode/message.py
+++ b/lib/python/flame/mode/message.py
@@ -37,4 +37,4 @@ class MessageType(Enum):
 
     MODEL_VERSION = 9  # model version used; an non-negative integer
 
-    STAT_UTILITY = 10  # measured utility of a client based on Oort
+    STAT_UTILITY = 10  # measured utility of a trainer based on Oort


### PR DESCRIPTION
The Oort algorithm requires calculation of round duration time per trainers to measure their system utility, which takes a role in determining which trainers to select at next round.

Before this PR, the implemention was calculating round duration time based on the time when the model update is handled at lib/python/flame/mode/horizontal/oort/top_aggregator.py, which could be inaccurate due to the usage of peek_buf on Ends.

Instead, this PR changes the implementation of current flame messaging, by letting it record the timestamp on the arrival of message at rx queue, which is at lib/python/flame/backend/chunk_manager.py.

To handle the timestamp information, message receive functionalities from lib/python/flame/channel.py and all aggregators and trainers have been changed accordingly.

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
