### PR TITLE
example/implementation for FedBalancer, with a new sampler category

### DIFF
--- a/lib/python/flame/config.py
+++ b/lib/python/flame/config.py
@@ -75,6 +75,13 @@ class SelectorType(str, Enum):
     OORT = "oort"
 
 
+class DataSamplerType(str, Enum):
+    """Define datasampler types."""
+
+    DEFAULT = "default"
+    FEDBALANCER = "fedbalancer"
+
+
 class Job(FlameSchema):
     job_id: str = Field(alias="id")
     name: str
@@ -87,6 +94,11 @@ class Registry(FlameSchema):
 
 class Selector(FlameSchema):
     sort: SelectorType = Field(default=SelectorType.DEFAULT)
+    kwargs: dict = Field(default={})
+
+
+class DataSampler(FlameSchema):
+    sort: DataSamplerType = Field(default=DataSamplerType.DEFAULT)
     kwargs: dict = Field(default={})
 
 
@@ -172,6 +184,7 @@ class Config(FlameSchema):
     job: Job
     registry: t.Optional[Registry]
     selector: t.Optional[Selector]
+    datasampler: t.Optional[DataSampler] = Field(default=DataSampler())
     optimizer: t.Optional[Optimizer] = Field(default=Optimizer())
     dataset: str
     max_run_time: int
@@ -223,6 +236,10 @@ def transform_config(raw_config: dict) -> dict:
 
     if raw_config.get("optimizer", None):
         config_data = config_data | {"optimizer": raw_config.get("optimizer")}
+
+    if raw_config.get("datasampler", None):
+        raw_config["datasampler"]["kwargs"].update(hyperparameters)
+        config_data = config_data | {"datasampler": raw_config.get("datasampler")}
 
     config_data = config_data | {
         "dataset": raw_config.get("dataset", ""),

--- a/lib/python/flame/datasampler/__init__.py
+++ b/lib/python/flame/datasampler/__init__.py
@@ -1,0 +1,78 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""datasampler abstract class."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from flame.channel import Channel
+
+
+class AbstractDataSampler(ABC):
+    class AbstractTrainerDataSampler(ABC):
+        """Abstract base class for trainer-side datasampler implementation."""
+
+        def __init__(self, **kwargs) -> None:
+            """Initialize an instance with keyword-based arguments."""
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+        @abstractmethod
+        def sample(self, dataset: Any, **kwargs) -> Any:
+            """Abstract method to sample data.
+
+            Parameters
+            ----------
+            dataset: Dataset of a trainer to select samples from
+            kwargs: other arguments specific to each datasampler algorithm
+
+            Returns
+            -------
+            dataset: Dataset that only contains selected samples
+            """
+
+        @abstractmethod
+        def load_dataset(self, dataset: Any) -> Any:
+            """Process dataset instance for datasampler."""
+
+        @abstractmethod
+        def get_metadata(self) -> dict[str, Any]:
+            """Return metadata to send to aggregator-side datasampler."""
+
+        @abstractmethod
+        def handle_metadata_from_aggregator(self, metadata: dict[str, Any]) -> None:
+            """Handle aggregator metadata for datasampler."""
+
+    class AbstractAggregatorDataSampler(ABC):
+        """Abstract base class for aggregator-side datasampler implementation."""
+
+        def __init__(self, **kwargs) -> None:
+            """Initialize an instance with keyword-based arguments."""
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+        @abstractmethod
+        def get_metadata(self, end: str, round: int) -> dict[str, Any]:
+            """Return metadata to send to trainer-side datasampler."""
+
+        @abstractmethod
+        def handle_metadata_from_trainer(
+            self,
+            metadata: dict[str, Any],
+            end: str,
+            channel: Channel,
+        ) -> None:
+            """Handle trainer metadata for datasampler."""

--- a/lib/python/flame/datasampler/default.py
+++ b/lib/python/flame/datasampler/default.py
@@ -1,0 +1,77 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""DefaultDataSampler class."""
+
+import logging
+from typing import Any
+
+from flame.channel import Channel
+from flame.datasampler import AbstractDataSampler
+
+logger = logging.getLogger(__name__)
+
+
+class DefaultDataSampler(AbstractDataSampler):
+    def __init__(self) -> None:
+        self.trainer_data_sampler = DefaultDataSampler.DefaultTrainerDataSampler()
+        self.aggregator_data_sampler = DefaultDataSampler.DefaultAggregatorDataSampler()
+
+    class DefaultTrainerDataSampler(AbstractDataSampler.AbstractTrainerDataSampler):
+        """A default trainer-side datasampler class."""
+
+        def __init__(self, **kwargs):
+            """Initailize instance."""
+            super().__init__()
+
+        def sample(self, dataset: Any, **kwargs) -> Any:
+            """Return all dataset from the given dataset."""
+            logger.debug("calling default datasampler")
+
+            return dataset
+
+        def load_dataset(self, dataset: Any) -> None:
+            """Change dataset instance to return index with each sample."""
+            return dataset
+
+        def get_metadata(self) -> dict[str, Any]:
+            """Return metadata to send to aggregator-side datasampler."""
+            return {}
+
+        def handle_metadata_from_aggregator(self, metadata: dict[str, Any]) -> None:
+            """Handle aggregator metadata for datasampler."""
+            pass
+
+    class DefaultAggregatorDataSampler(
+        AbstractDataSampler.AbstractAggregatorDataSampler
+    ):
+        """A default aggregator-side datasampler class."""
+
+        def __init__(self, **kwargs):
+            """Initailize instance."""
+            super().__init__()
+
+        def get_metadata(self, end: str, round: int) -> dict[str, Any]:
+            """Return metadata to send to trainer-side datasampler."""
+            return {}
+
+        def handle_metadata_from_trainer(
+            self,
+            metadata: dict[str, Any],
+            end: str,
+            channel: Channel,
+        ) -> None:
+            """Handle trainer metadata for datasampler."""
+            pass

--- a/lib/python/flame/datasampler/fedbalancer.py
+++ b/lib/python/flame/datasampler/fedbalancer.py
@@ -1,0 +1,572 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""FedBalancerDataSampler class."""
+
+import logging
+import sys
+import math
+import numpy as np
+from typing import Any
+
+from flame.channel import Channel
+from flame.common.util import MLFramework, get_ml_framework_in_use
+from flame.datasampler import AbstractDataSampler
+
+logger = logging.getLogger(__name__)
+
+PROP_ROUND_START_TIME = "round_start_time"
+PROP_ROUND_END_TIME = "round_end_time"
+
+
+class FedBalancerDataSampler(AbstractDataSampler):
+    def __init__(self, **kwargs) -> None:
+        self.trainer_data_sampler = (
+            FedBalancerDataSampler.FedBalancerTrainerDataSampler(**kwargs)
+        )
+        self.aggregator_data_sampler = (
+            FedBalancerDataSampler.FedBalancerAggregatorDataSampler(**kwargs)
+        )
+
+    class FedBalancerTrainerDataSampler(AbstractDataSampler.AbstractTrainerDataSampler):
+        """A trainer-side datasampler class based on FedBalancer."""
+
+        def __init__(self, **kwargs):
+            """Initailize instance."""
+            super().__init__(**kwargs)
+
+            ml_framework_in_use = get_ml_framework_in_use()
+            if ml_framework_in_use != MLFramework.PYTORCH:
+                raise NotImplementedError(
+                    "FedBalancer is currently only implemented in PyTorch;"
+                )
+
+            import torch as T
+
+            self.torch = T
+
+            try:
+                # Fedbalancer parameters
+
+                # window size for round benefit calculation
+                self._w = kwargs["w"]
+                # loss threshold step size
+                self._lss = kwargs["lss"]
+                # deadline step size
+                self._dss = kwargs["dss"]
+                # portion to sample from over threshold group
+                self._p = kwargs["p"]
+                # noise factor for differential privacy
+                self._noise_factor = kwargs["noise_factor"]
+
+                # General training hyperparameters
+
+                self.epochs = kwargs["epochs"]
+                self.batch_size = kwargs["batchSize"]
+
+            except KeyError:
+                raise KeyError(
+                    "one of the parameters among {w, lss, dss, p, noise_factor} "
+                    + "is not specified in config,\nrecommended set of parameters"
+                    + "are {20, 0.05, 0.05, 1.0, 0.0}"
+                )
+
+            self._loss_threshold = 0
+            # Terminating a round with deadline is required in FedBalancer,
+            # but not yet implemented in the current implementation.
+            self._deadline = sys.maxsize
+
+            self._stat_utility = 0
+            self._ot_count = 0
+            self._is_first_selected_round = True
+
+            self._selected_loss_sum = 0
+            self._selected_len = 0
+
+            self._sample_loss_list = []
+            self._train_duration_per_batch_list = []
+            self._round_train_batch_count = 0
+
+        def sample(self, dataset: Any, **kwargs) -> Any:
+            """Select sample from the given dataset following FedBalancer algorithm."""
+            logger.debug("calling fedbalancer datasampler")
+
+            # calculate loss of train data samples only on its first selected round
+            if self._is_first_selected_round:
+                self._build_fb_sample_loss_dict(
+                    dataset, kwargs["loss_fn"], kwargs["model"], kwargs["device"]
+                )
+
+            # calculate max trainable size of a trainer for epochs at current deadline
+            max_trainable_size = 0
+            if not self._is_first_selected_round:
+                max_trainable_size = self._calculate_max_trainable_size()
+
+            # if a client is fast enough to train its whole data for epochs within the
+            # deadline, select all data
+            if not self._is_first_selected_round and max_trainable_size > len(dataset):
+                sampled_indices = list(range(len(dataset)))
+                sampled_dataset = dataset
+            else:
+                # sample indexes with underthreshold loss (ut) and overthreshold loss (ot)
+                ut_indices, ot_indices = [], []
+
+                # read through the sample loss list and parse it in ut or ot indices lists,
+                # based on the loss threshold value
+                for idx, item in enumerate(self._sample_loss_list):
+                    if item < self._loss_threshold:
+                        ut_indices.append(idx)
+                    else:
+                        ot_indices.append(idx)
+
+                # determine the number of samples to select from ut and ot group,
+                # according to the fedbalancer paper
+                sample_num = max(max_trainable_size, len(ot_indices))
+                ut_sample_len = int(sample_num * (1 - self._p))
+                ot_sample_len = sample_num - ut_sample_len
+
+                # random sample from ut and ot without replacement
+                sampled_ut_indices = np.random.choice(ut_indices, ut_sample_len, False)
+                sampled_ot_indices = np.random.choice(ot_indices, ot_sample_len, False)
+
+                sampled_indices = [*sampled_ut_indices, *sampled_ot_indices]
+
+                sampled_dataset = self.torch.utils.data.Subset(dataset, sampled_indices)
+
+            # calculate selected samples' loss sum and len as fedbalancer metadata,
+            # that is being sent back to the aggregator for the calculation of
+            # a new loss_threshold
+            self._selected_loss_sum = 0
+
+            for sample_index in sampled_indices:
+                self._selected_loss_sum += self._sample_loss_list[sample_index]
+
+            self._selected_len = len(sampled_indices)
+
+            # reset number of trained batch count at current round with new sampled dataset
+            self._round_train_batch_count = 0
+
+            if self._is_first_selected_round:
+                self._is_first_selected_round = False
+
+            return sampled_dataset
+
+        def load_dataset(self, dataset: Any) -> Any:
+            """Change dataset instance to return index with each sample."""
+            from flame.datasampler.util import PyTorchDatasetWithIndex
+
+            return PyTorchDatasetWithIndex(dataset)
+
+        def get_metadata(self) -> dict[str, Any]:
+            """
+            Returns the metadata of trainers of fedbalancer to send to
+            aggregator for new loss_threshold and deadline calculation
+            """
+            # measure differentially-private statisticcs of sample loss values as metadata
+            loss_low, loss_high = self._measure_DP_stats()
+
+            # measure train duration per epoch for the current round
+            epoch_train_duration = int(
+                self._selected_len / self.batch_size + 1
+            ) * np.mean(
+                self._train_duration_per_batch_list[-self._round_train_batch_count :]
+            )
+
+            return {
+                "loss_low": loss_low,
+                "loss_high": loss_high,
+                "selected_loss_sum": self._selected_loss_sum,
+                "selected_len": self._selected_len,
+                "epoch_train_duration": epoch_train_duration,
+            }
+
+        def handle_metadata_from_aggregator(self, metadata: dict[str, Any]) -> None:
+            """
+            Handle received metadata from aggregator.
+            """
+            self._loss_threshold = metadata["loss_threshold"]
+            self._deadline = metadata["deadline"]
+
+        def _build_fb_sample_loss_dict(
+            self,
+            dataset: Any,
+            loss_fn: Any,
+            model: Any,
+            device: str,
+        ) -> None:
+            """
+            Calculate loss of train data samples of a trainer
+            on its first selected round.
+            """
+
+            # initialize sample loss list with a pair of index and loss value as zero
+            self._sample_loss_list = [0 for _ in range(len(dataset))]
+            full_samples_loader = self.torch.utils.data.DataLoader(
+                dataset, batch_size=len(dataset)
+            )
+
+            with self.torch.no_grad():
+                for sample in full_samples_loader:
+                    data, target = sample[0].to(device), sample[1].to(device)
+                    indices = sample[2]
+
+                    output = model(data)
+                    loss_list = loss_fn(output, target, reduction="none")
+
+                    for k, idx in enumerate(indices):
+                        self._sample_loss_list[idx] = loss_list[k]
+
+        def _calculate_max_trainable_size(self) -> int:
+            """
+            Calculate max trainable size of a trainer for epochs
+            at current deadline.
+            """
+            num_of_trainable_batches = (
+                self._deadline
+                / (self.epochs * np.mean(self._train_duration_per_batch_list))
+                - 1
+            )
+            max_trainable_size = int(num_of_trainable_batches * self.batch_size - 1)
+
+            return max_trainable_size
+
+        def fb_loss(
+            self,
+            loss_fn: Any,
+            output: Any,
+            target: Any,
+            epoch: int,
+            indices: list[int],
+        ) -> Any:
+            """
+            Measure the loss of a trainer during training.
+            The trainer's statistical utility is measured at epoch 1.
+            """
+            if epoch == 1:
+                loss_list = loss_fn(output, target, reduction="none")
+                loss = loss_list.mean()
+
+                # update the loss at the self._sample_loss_list with values
+                # that are acquired during training
+                for k, loss in enumerate(loss_list):
+                    self._sample_loss_list[indices[k]] = loss.item()
+
+                # filter loss list to only calculate utility with loss values
+                # that have bigger loss than the loss threshold
+                loss_list = self.torch.where(
+                    loss_list >= self._loss_threshold,
+                    loss_list,
+                    self.torch.zeros_like(loss_list),
+                )
+
+                # count the samples with overthreshold loss values for normalization
+                self._ot_count += self.torch.count_nonzero(
+                    loss_list >= self._loss_threshold
+                ).item()
+
+                self._stat_utility += self.torch.square(loss_list).sum()
+            else:
+                loss = loss_fn(output, target)
+
+            return loss
+
+        def normalize_stat_utility(self, epoch) -> None:
+            """
+            Normalize statistical utility of a trainer based on the size
+            of the trainer's datset, at epoch 1.
+            """
+            if epoch == 1:
+                self._stat_utility = self._ot_count * math.sqrt(
+                    self._stat_utility / self._ot_count
+                )
+            else:
+                return
+
+        def reset_stat_utility(self) -> None:
+            """Reset the trainer's statistical utility to zero."""
+            self._stat_utility = 0
+            self._ot_count = 0
+
+        def update_train_duration_per_batch_list(self, time: float) -> None:
+            """Append the train duration per batch to the list."""
+            self._train_duration_per_batch_list.append(time)
+            self._round_train_batch_count += 1
+
+        def _measure_DP_stats(self) -> tuple[float, float]:
+            """
+            Measure the differentially-private statistics of sample loss values
+            according to the FedBalancer paper
+            """
+            loss_list = []
+            for loss in self._sample_loss_list:
+                loss_list.append(loss)
+
+            dp_noise_1 = np.random.normal(0, self._noise_factor, 1)[0]
+            dp_noise_2 = np.random.normal(0, self._noise_factor, 1)[0]
+
+            loss_low = np.min(loss_list) + dp_noise_1
+            loss_high = np.percentile(loss_list, 80) + dp_noise_2
+
+            return loss_low, loss_high
+
+    class FedBalancerAggregatorDataSampler(
+        AbstractDataSampler.AbstractAggregatorDataSampler
+    ):
+        """An aggregator-side datasampler class based on FedBalancer."""
+
+        def __init__(self, **kwargs):
+            """Initailize instance."""
+            super().__init__(**kwargs)
+
+            try:
+                # Fedbalancer parameters
+
+                # window size for round benefit calculation
+                self._w = kwargs["w"]
+                # loss threshold step size
+                self._lss = kwargs["lss"]
+                # deadline step size
+                self._dss = kwargs["dss"]
+                # portion to sample from over threshold group
+                self._p = kwargs["p"]
+                # noise factor for differential privacy
+                self._noise_factor = kwargs["noise_factor"]
+
+                # General training hyperparameters
+
+                self.epochs = kwargs["epochs"]
+                self.batch_size = kwargs["batchSize"]
+
+            except KeyError:
+                raise KeyError(
+                    "one of the parameters among {w, lss, dss, p, noise_factor} "
+                    + "is not specified in config,\nrecommended set of parameters"
+                    + "are {20, 0.05, 0.05, 1.0, 0.0}"
+                )
+
+            self._loss_threshold = 0
+            # Terminating a round with deadline is required in FedBalancer,
+            # but not yet implemented in the current implementation.
+            self._deadline = sys.maxsize
+
+            self._ltr = 0.0
+            self._ddlr = 1.0
+
+            self._round_benefit_history = []
+            self._round_duration_history = {}
+            self._round_epoch_train_duration_history = {}
+            self._round_communication_duration_history = {}
+
+            self._curr_round_loss_low = []
+            self._curr_round_loss_high = []
+            self._curr_round_selected_loss_sum = []
+            self._curr_round_selected_len = []
+
+        def get_metadata(self, round: int, selected_ends: list[str]) -> dict[str, Any]:
+            """
+            Returns the metadata variables of aggregator of fedbalancer
+            that are distributed on trainers for sample selection.
+            To this end, update loss threshold ratio and deadline ratio based on the
+            round benefit history, then update loss threshold and deadline.
+            Also, reset aggregator variables for current round.
+            """
+
+            # skips update fb variables if first round
+            if round >= 2:
+                self._update_fb_ratio(round)
+                self._update_fb_loss_threshold()
+                self._update_fb_deadline(selected_ends)
+
+                (
+                    self._curr_round_loss_low,
+                    self._curr_round_loss_high,
+                    self._curr_round_selected_loss_sum,
+                    self._curr_round_selected_len,
+                ) = ([], [], [], [])
+
+            metadata = {
+                "loss_threshold": self._loss_threshold,
+                "deadline": self._deadline,
+            }
+
+            return metadata
+
+        def handle_metadata_from_trainer(
+            self,
+            metadata: dict[str, Any],
+            end: str,
+            channel: Channel,
+        ) -> None:
+            """
+            Handles the metadata of fedbalancer from trainers for
+            new loss_threshold and deadline calculation
+            """
+
+            # add loss related metadata to list
+            self._curr_round_loss_low.append(metadata["loss_low"])
+            self._curr_round_loss_high.append(metadata["loss_high"])
+            self._curr_round_selected_loss_sum.append(metadata["selected_loss_sum"])
+            self._curr_round_selected_len.append(metadata["selected_len"])
+
+            # calculate the time duration of train and communication from curr round
+            round_start_time_tup = channel.get_end_property(end, PROP_ROUND_START_TIME)
+            round_end_time_tup = channel.get_end_property(end, PROP_ROUND_END_TIME)
+            if round_start_time_tup[0] == round_end_time_tup[0]:
+                round_duration = (
+                    round_end_time_tup[1] - round_start_time_tup[1]
+                ).total_seconds()
+            elif end in self._round_duration_history.keys():
+                round_duration = self._round_duration_history[-1]
+            else:
+                return
+
+            round_epoch_train_duration = metadata["epoch_train_duration"]
+            round_communication_duration = (
+                round_duration - self.epochs * round_epoch_train_duration
+            )
+
+            # save duration information. Check if the history list exists for this end
+            # and append the information at the list
+            if end not in self._round_duration_history.keys():
+                self._round_duration_history[end] = []
+            if end not in self._round_epoch_train_duration_history.keys():
+                self._round_epoch_train_duration_history[end] = []
+            if end not in self._round_communication_duration_history.keys():
+                self._round_communication_duration_history[end] = []
+
+            self._round_duration_history[end].append(round_duration)
+            self._round_epoch_train_duration_history[end].append(
+                round_epoch_train_duration
+            )
+            self._round_communication_duration_history[end].append(
+                round_communication_duration
+            )
+
+            # we maintain the duration history of last 5 times which an end participated
+            # at a round, according to the implementation of FedBalancer authors:
+            # https://github.com/jaemin-shin/FedBalancer,
+            # Commit 1d187c88de9b5b43e28c988b2423e9f616c80610
+            self._round_duration_history[end] = self._round_duration_history[end][-5:]
+            self._round_epoch_train_duration_history[
+                end
+            ] = self._round_epoch_train_duration_history[end][-5:]
+            self._round_communication_duration_history[
+                end
+            ] = self._round_communication_duration_history[end][-5:]
+
+        def _update_fb_ratio(self, round: int) -> None:
+            """
+            Update loss threshold ratio and deadline ratio based on the
+            round benefit history.
+            """
+
+            # calculate the benefit of a round on the current configuration
+            # with loss threshold and the deadline, then add it to history list
+            curr_round_loss_sum = sum(self._curr_round_selected_loss_sum)
+            curr_round_selected_len = sum(self._curr_round_selected_len)
+
+            curr_round_benefit = (
+                curr_round_loss_sum / curr_round_selected_len
+            ) / self._deadline
+
+            self._round_benefit_history.append(curr_round_benefit)
+
+            lss = self._lss
+            dss = self._dss
+
+            # use round - 1 here as curr_round loss sum and selected len info
+            # are from last round
+            if (round - 1) % self._w == self._w - 1:
+                if len(self._round_benefit_history) >= 2 * self._w:
+                    last_window_benefit = np.mean(
+                        self._round_benefit_history[-(self._w * 2) : -(self._w)]
+                    )
+                    curr_window_benefit = np.mean(
+                        self._round_benefit_history[-(self._w) :]
+                    )
+
+                    if last_window_benefit - curr_window_benefit > 0:
+                        self._ltr = min(self._ltr + lss, 1.0)
+                        self._ddlr = max(self._ddlr - dss, 0.0)
+                    else:
+                        self._ltr = max(self._ltr - lss, 0.0)
+                        self._ddlr = min(self._ddlr + dss, 1.0)
+
+                    logger.debug(f"{self._ltr=}, {self._ddlr=}")
+
+        def _update_fb_loss_threshold(self) -> None:
+            """
+            Update fedbalancer loss threshold based on the received
+            loss_low values and loss_high values from a round.
+            """
+
+            # is loss_threshold_ratio (ltr) is 0 and loss_threshold is 0, it means
+            # the training is in early stage, so leave loss_threshold as 0
+            if self._loss_threshold == 0 and self._ltr == 0:
+                logger.debug(f"{self._loss_threshold=}")
+                return
+
+            loss_low = np.min(self._curr_round_loss_low)
+            loss_high = np.mean(self._curr_round_loss_high)
+
+            self._loss_threshold = loss_low + (loss_high - loss_low) * self._ltr
+
+            logger.debug(f"{loss_low=}, {loss_high=}, {self._loss_threshold=}")
+
+        def _update_fb_deadline(self, selected_ends: list[str]) -> None:
+            """
+            Update fedbalancer deadline based on the round duration times of
+            trianers from previous rounds.
+            """
+            deadline_low = self._find_peak_DDLE(selected_ends, 1)
+            deadline_high = self._find_peak_DDLE(selected_ends, self.epochs)
+
+            self._deadline = deadline_low + (deadline_high - deadline_low) * self._ddlr
+
+            logger.debug(f"{deadline_low=}, {deadline_high=}, {self._deadline=}")
+
+        def _find_peak_DDLE(self, selected_ends: list[str], epoch: int) -> int:
+            """
+            Search for deadline that results in max DDL-E (deadline efficiency) value
+            when trainers (ends) train for specified number of epoch, as in fedbalancer.
+            """
+            max_DDLE_value = -1
+            max_DDLE_time = -1
+
+            expected_end_complete_time = {}
+
+            for end in selected_ends:
+                if end in self._round_communication_duration_history.keys():
+                    expected_end_complete_time[end] = (
+                        np.mean(self._round_communication_duration_history[end])
+                        + np.mean(self._round_epoch_train_duration_history[end]) * epoch
+                    )
+
+            for candidate_deadline in range(1, sys.maxsize):
+                round_complete_end_count = 0
+                for end in expected_end_complete_time.keys():
+                    if expected_end_complete_time[end] <= candidate_deadline:
+                        round_complete_end_count += 1
+
+                curr_DDLE_value = round_complete_end_count / candidate_deadline
+
+                if max_DDLE_value < curr_DDLE_value:
+                    max_DDLE_value = curr_DDLE_value
+                    max_DDLE_time = candidate_deadline
+
+                if round_complete_end_count == len(expected_end_complete_time.keys()):
+                    break
+
+            return max_DDLE_time

--- a/lib/python/flame/datasampler/util.py
+++ b/lib/python/flame/datasampler/util.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+from torch.utils.data import Dataset
+
+
+class PyTorchDatasetWithIndex(Dataset):
+    """
+    PyTorch Dataset class that returns tuple of
+    data, target, index.
+    """
+
+    def __init__(self, dataset: Dataset) -> None:
+        """Initialize with existing Dataset instance."""
+
+        self.dataset = dataset
+
+    def __getitem__(self, index):
+        """Adds index at the return tuple item."""
+
+        data, target = self.dataset[index]
+        return data, target, index
+
+    def __len__(self):
+        """Returns the length of the dataset."""
+
+        return len(self.dataset)

--- a/lib/python/flame/datasamplers.py
+++ b/lib/python/flame/datasamplers.py
@@ -1,0 +1,34 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""sampler provider class."""
+
+from flame.config import DataSamplerType
+from flame.object_factory import ObjectFactory
+from flame.datasampler.default import DefaultDataSampler
+from flame.datasampler.fedbalancer import FedBalancerDataSampler
+
+
+class DataSamplerProvider(ObjectFactory):
+    """DataSampler Provider."""
+
+    def get(self, datasampler_name, **kwargs):
+        """Return a datasampler for a given datasampler name."""
+        return self.create(datasampler_name, **kwargs)
+
+
+datasampler_provider = DataSamplerProvider()
+datasampler_provider.register(DataSamplerType.DEFAULT, DefaultDataSampler)
+datasampler_provider.register(DataSamplerType.FEDBALANCER, FedBalancerDataSampler)

--- a/lib/python/flame/end.py
+++ b/lib/python/flame/end.py
@@ -20,9 +20,9 @@ from typing import Union
 
 from .common.typing import Scalar
 
-KEY_END_STATE = 'state'
-VAL_END_STATE_RECVD = 'recvd'
-VAL_END_STATE_NONE = ''
+KEY_END_STATE = "state"
+VAL_END_STATE_RECVD = "recvd"
+VAL_END_STATE_NONE = ""
 
 
 class End(object):

--- a/lib/python/flame/examples/fedbalancer_mnist/README.md
+++ b/lib/python/flame/examples/fedbalancer_mnist/README.md
@@ -1,0 +1,36 @@
+## FedBalancer MNIST Example
+
+We use MNIST for an example of FedBalancer, which is a trainer (client) sample selection framework for acclerated federated learning proposed by:
+
+> [MobiSys'22](https://www.sigmobile.org/mobisys/2022/)
+>
+> [FedBalancer: Data and Pace Control for Efficient Federated Learning on Heterogeneous Clients
+](https://arxiv.org/abs/2201.01601)
+
+
+This example runs within the `conda` environment.
+After installing Flame SDK into `flame` environment, change directory to `lib/python/flame/examples/fedbalancer_mnist`, and run the following command.
+
+```bash
+$ conda activate flame
+```
+
+When running FedBalancer, you need to specify the number of trainers, and FedBalancer parameters `{w, lss, dss, p, noise_factor}`.
+Please refer to FedBalancer paper for more details about the parameters.
+The recommended set of parameters are: `{w, lss, dss, p, noise_factor} = {20, 0.05, 0.05, 1.0, 0.0}`
+
+To run FL with FedBalancer using 20 trainers and recommended set of parameters, you can run:
+
+```bash
+$ python run.py {num_of_total_trainers} {w} {lss} {dss} {p} {noise_factor}
+
+# EXAMPLE:
+# python run.py 20 20 0.05 0.05 1.0 0.0
+```
+
+You can track the progress by running the following commands:
+
+```bash
+$ cat output/aggregator/aggregator.log
+```
+

--- a/lib/python/flame/examples/fedbalancer_mnist/__init__.py
+++ b/lib/python/flame/examples/fedbalancer_mnist/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/lib/python/flame/examples/fedbalancer_mnist/aggregator/__init__.py
+++ b/lib/python/flame/examples/fedbalancer_mnist/aggregator/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/lib/python/flame/examples/fedbalancer_mnist/aggregator/main.py
+++ b/lib/python/flame/examples/fedbalancer_mnist/aggregator/main.py
@@ -1,0 +1,144 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""MNIST horizontal FL aggregator for PyTorch.
+
+The example below is implemented based on the following example from pytorch:
+https://github.com/pytorch/examples/blob/master/mnist/main.py.
+"""
+
+import logging
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from flame.config import Config
+from flame.dataset import Dataset
+from flame.mode.horizontal.top_aggregator import TopAggregator
+from torchvision import datasets, transforms
+
+logger = logging.getLogger(__name__)
+
+
+class Net(nn.Module):
+    """Net class."""
+
+    def __init__(self):
+        """Initialize."""
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        """Forward."""
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+class PyTorchOortMnistAggregator(TopAggregator):
+    """PyTorch Oort Mnist Aggregator."""
+
+    def __init__(self, config: Config) -> None:
+        """Initialize a class instance."""
+        self.config = config
+        self.model = None
+        self.dataset: Dataset = None
+
+        self.device = None
+        self.test_loader = None
+
+    def initialize(self):
+        """Initialize role."""
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        self.model = Net().to(self.device)
+
+    def load_data(self) -> None:
+        """Load a test dataset."""
+        transform = transforms.Compose(
+            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+        )
+
+        dataset = datasets.MNIST(
+            "./data", train=False, download=True, transform=transform
+        )
+
+        self.test_loader = torch.utils.data.DataLoader(dataset)
+
+        # store data into dataset for analysis (e.g., bias)
+        self.dataset = Dataset(dataloader=self.test_loader)
+
+    def train(self) -> None:
+        """Train a model."""
+        # Implement this if testing is needed in aggregator
+        pass
+
+    def evaluate(self) -> None:
+        """Evaluate (test) a model."""
+        self.model.eval()
+        test_loss = 0
+        correct = 0
+        with torch.no_grad():
+            for data, target in self.test_loader:
+                data, target = data.to(self.device), target.to(self.device)
+                output = self.model(data)
+                test_loss += F.nll_loss(
+                    output, target, reduction="sum"
+                ).item()  # sum up batch loss
+                pred = output.argmax(
+                    dim=1, keepdim=True
+                )  # get the index of the max log-probability
+                correct += pred.eq(target.view_as(pred)).sum().item()
+
+        total = len(self.test_loader.dataset)
+        test_loss /= total
+        test_accuray = correct / total
+
+        logger.info(f"Test loss: {test_loss}")
+        logger.info(f"Test accuracy: {correct}/{total} ({test_accuray})")
+
+        # update metrics after each evaluation so that the metrics can be
+        # logged in a model registry.
+        self.update_metrics({"test-loss": test_loss, "test-accuracy": test_accuray})
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument("config", nargs="?", default="./config.json")
+
+    args = parser.parse_args()
+
+    config = Config(args.config)
+
+    a = PyTorchOortMnistAggregator(config)
+    a.compose()
+    a.run()

--- a/lib/python/flame/examples/fedbalancer_mnist/config/agg_template.json
+++ b/lib/python/flame/examples/fedbalancer_mnist/config/agg_template.json
@@ -1,0 +1,86 @@
+{
+    "taskid": "49d06b7526964db86cf37c70e8e0cdb6bd7aa742",
+    "backend": "mqtt",
+    "brokers": [
+        {
+            "host": "localhost",
+            "sort": "mqtt"
+        },
+        {
+            "host": "localhost:10104",
+            "sort": "p2p"
+        }
+    ],
+    "groupAssociation": {
+        "param-channel": "default"
+    },
+    "channels": [
+        {
+            "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default"
+                ]
+            },
+            "name": "param-channel",
+            "pair": [
+                "trainer",
+                "aggregator"
+            ],
+            "funcTags": {
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
+            }
+        }
+    ],
+    "dataset": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz",
+    "dependencies": [
+        "numpy >= 1.2.0"
+    ],
+    "hyperparameters": {
+        "batchSize": 32,
+        "learningRate": 0.01,
+        "rounds": 20,
+        "epochs": 1
+    },
+    "baseModel": {
+        "name": "",
+        "version": 2
+    },
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "mnist"
+    },
+    "registry": {
+        "sort": "dummy",
+        "uri": ""
+    },
+    "selector": {
+        "sort": "default",
+        "kwargs": {}
+    },
+    "datasampler": {
+        "sort": "fedbalancer",
+        "kwargs": {
+            "w": 20,
+            "lss": 0.05,
+            "dss": 0.05,
+            "p": 1.0,
+            "noise_factor": 0.0
+        }
+    },
+    "optimizer": {
+        "sort": "fedavg",
+        "kwargs": {}
+    },
+    "maxRunTime": 300,
+    "realm": "default",
+    "role": "aggregator"
+}

--- a/lib/python/flame/examples/fedbalancer_mnist/config/train_template.json
+++ b/lib/python/flame/examples/fedbalancer_mnist/config/train_template.json
@@ -1,0 +1,86 @@
+{
+    "taskid": "505f9fc483cf4df68a2409257b5fad7d3c580370",
+    "backend": "mqtt",
+    "brokers": [
+        {
+            "host": "localhost",
+            "sort": "mqtt"
+        },
+        {
+            "host": "localhost:10104",
+            "sort": "p2p"
+        }
+    ],
+    "groupAssociation": {
+        "param-channel": "default"
+    },
+    "channels": [
+        {
+            "description": "Model update is sent from trainer to aggregator and vice-versa",
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default"
+                ]
+            },
+            "name": "param-channel",
+            "pair": [
+                "trainer",
+                "aggregator"
+            ],
+            "funcTags": {
+                "aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ]
+            }
+        }
+    ],
+    "dataset": "https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz",
+    "dependencies": [
+        "numpy >= 1.2.0"
+    ],
+    "hyperparameters": {
+        "batchSize": 32,
+        "learningRate": 0.01,
+        "rounds": 5,
+        "epochs": 1
+    },
+    "baseModel": {
+        "name": "",
+        "version": 1
+    },
+    "job": {
+        "id": "622a358619ab59012eabeefb",
+        "name": "mnist"
+    },
+    "registry": {
+        "sort": "dummy",
+        "uri": ""
+    },
+    "selector": {
+        "sort": "default",
+        "kwargs": {}
+    },
+    "datasampler": {
+        "sort": "fedbalancer",
+        "kwargs": {
+            "w": 20,
+            "lss": 0.05,
+            "dss": 0.05,
+            "p": 1.0,
+            "noise_factor": 0.0
+        }
+    },
+    "optimizer": {
+        "sort": "fedavg",
+        "kwargs": {}
+    },
+    "maxRunTime": 300,
+    "realm": "default/us/west",
+    "role": "trainer"
+}

--- a/lib/python/flame/examples/fedbalancer_mnist/run.py
+++ b/lib/python/flame/examples/fedbalancer_mnist/run.py
@@ -1,0 +1,84 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import json
+
+# get trial
+if len(sys.argv) != 7:
+    # logger?
+    raise Exception(
+        "Wrong number of arguments; expected 6\nExample usage: "
+        + "python run.py (num of total trainers) (w) (lss) (dss) (p) (noise_factor)\n"
+        + "please refer to FedBalancer paper for the use of each parameters"
+    )
+
+total_trainer_num = int(sys.argv[1])
+w = int(sys.argv[2])
+lss = float(sys.argv[3])
+dss = float(sys.argv[4])
+p = float(sys.argv[5])
+noise_factor = float(sys.argv[6])
+
+# generate json files
+job_id = "622a358619ab59012eabeefb"
+task_id = 0
+
+
+def generate_config(filename, num):
+    # load json data
+    input_filename = "config/train_template.json" if num else "config/agg_template.json"
+    file = open(input_filename, "r")
+    data = json.load(file)
+    data["job"]["id"] = job_id
+    data["datasampler"]["kwargs"]["w"] = w
+    data["datasampler"]["kwargs"]["lss"] = lss
+    data["datasampler"]["kwargs"]["dss"] = dss
+    data["datasampler"]["kwargs"]["p"] = p
+    data["datasampler"]["kwargs"]["noise_factor"] = noise_factor
+
+    data["taskid"] = f"{str(task_id+num)}" if num else str(task_id)
+
+    # save json data
+    file = open(filename, "w+")
+    file.write(json.dumps(data, indent=4))
+    file.close()
+
+
+# make directory for output files
+os.system("mkdir output")
+os.system("mkdir output/aggregator")
+os.system("mkdir output/trainer")
+
+for i in range(1, total_trainer_num + 1):
+    filename = f"config/trainer{i}.json"
+    generate_config(filename, i)
+
+    os.chdir("trainer")
+    os.system(
+        f"python main.py ../config/trainer{i}.json > ../output/trainer/trainer{i}.log 2>&1 &"
+    )
+    os.chdir("..")
+
+filename = "config/aggregator.json"
+generate_config(filename, 0)
+
+os.chdir("aggregator")
+os.system(
+    "python main.py ../config/aggregator.json > ../output/aggregator/aggregator.log 2>&1 &"
+)
+os.chdir("..")

--- a/lib/python/flame/examples/fedbalancer_mnist/trainer/__init__.py
+++ b/lib/python/flame/examples/fedbalancer_mnist/trainer/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/lib/python/flame/examples/fedbalancer_mnist/trainer/main.py
+++ b/lib/python/flame/examples/fedbalancer_mnist/trainer/main.py
@@ -1,0 +1,176 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""MNIST horizontal FL trainer for PyTorch.
+
+The example below is implemented based on the following example from pytorch:
+https://github.com/pytorch/examples/blob/master/mnist/main.py.
+"""
+
+import logging
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+import torch.utils.data as data_utils
+from datetime import datetime
+from flame.config import Config
+from flame.mode.horizontal.trainer import Trainer
+
+
+from torchvision import datasets, transforms
+
+logger = logging.getLogger(__name__)
+
+
+class Net(nn.Module):
+    """Net class."""
+
+    def __init__(self):
+        """Initialize."""
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        """Forward."""
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+class PyTorchFedBalancerMnistTrainer(Trainer):
+    """PyTorch FedBalancer Mnist Trainer."""
+
+    def __init__(self, config: Config) -> None:
+        """Initialize a class instance."""
+        self.config = config
+        self.dataset_size = 0
+        self.model = None
+
+        self.device = None
+        self.train_loader = None
+
+        self.epochs = self.config.hyperparameters.epochs
+        self.batch_size = self.config.hyperparameters.batch_size or 16
+
+    def initialize(self) -> None:
+        """Initialize role."""
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        self.model = Net().to(self.device)
+
+    def load_data(self) -> None:
+        """Load data."""
+        transform = transforms.Compose(
+            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+        )
+
+        self.dataset = datasets.MNIST(
+            "./data", train=True, download=True, transform=transform
+        )
+
+        indices = torch.arange(2000)
+        self.dataset = data_utils.Subset(self.dataset, indices)
+        self.dataset = self.datasampler.load_dataset(self.dataset)
+
+        self.train_kwargs = {"batch_size": self.batch_size}
+
+    def train(self) -> None:
+        """Train a model."""
+
+        sampled_dataset = self.datasampler.sample(
+            self.dataset, loss_fn=F.nll_loss, model=self.model, device=self.device
+        )
+
+        self.train_loader = torch.utils.data.DataLoader(
+            sampled_dataset, **self.train_kwargs
+        )
+
+        self.optimizer = optim.Adadelta(self.model.parameters())
+
+        for epoch in range(1, self.epochs + 1):
+            self._train_epoch(epoch)
+
+        # save dataset size so that the info can be shared with aggregator
+        self.dataset_size = len(self.train_loader.dataset)
+
+    def _train_epoch(self, epoch):
+        self.model.train()
+        self.datasampler.reset_stat_utility()
+
+        for batch_idx, sample in enumerate(self.train_loader):
+            batch_train_start_time = datetime.now()
+
+            data, target = sample[0].to(self.device), sample[1].to(self.device)
+            indices = sample[2]
+
+            self.optimizer.zero_grad()
+            output = self.model(data)
+
+            # calculate statistical utility of a trainer while calculating loss
+            loss = self.datasampler.fb_loss(F.nll_loss, output, target, epoch, indices)
+
+            loss.backward()
+            self.optimizer.step()
+            if batch_idx % 10 == 0:
+                done = batch_idx * len(data)
+                total = len(self.train_loader.dataset)
+                percent = 100.0 * batch_idx / len(self.train_loader)
+                logger.info(
+                    f"epoch: {epoch} [{done}/{total} ({percent:.0f}%)]"
+                    f"\tloss: {loss.item():.6f}"
+                )
+
+            batch_train_end_time = datetime.now()
+            self.datasampler.update_train_duration_per_batch_list(
+                (batch_train_end_time - batch_train_start_time).total_seconds()
+            )
+
+        # normalize statistical utility of a trainer based on the size of the dataset
+        self.datasampler.normalize_stat_utility(epoch)
+
+    def evaluate(self) -> None:
+        """Evaluate a model."""
+        # Implement this if testing is needed in trainer
+        pass
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument("config", nargs="?", default="./config.json")
+
+    args = parser.parse_args()
+    config = Config(args.config)
+
+    t = PyTorchFedBalancerMnistTrainer(config)
+    t.compose()
+    t.run()

--- a/lib/python/flame/mode/message.py
+++ b/lib/python/flame/mode/message.py
@@ -40,3 +40,5 @@ class MessageType(Enum):
     STAT_UTILITY = 10  # measured utility of a trainer based on Oort
 
     COORDINATED_ENDS = 11  # ends coordinated by a coordinator
+
+    DATASAMPLER_METADATA = 12  # datasampler metadata


### PR DESCRIPTION
Add a new category, "sampler", which selects trainers' data at FL rounds.

Add FedBalancer (Jaemin Shin et al., FedBalancer: Data and Pace Control for Efficient Federated Learning on Heterogeneous Clients, MobiSys'22) as a new sampler, which actively selects more important training samples of trainers to speed up global FL. Implement a control scheme of "deadline", which is only used for fedbalancer's sample selection at this version. Deadline-based round termination will be supported in later updates.

Refer to lib/python/flame/examples/fedbalancer_mnist/ for example of running fedbalancer

Things that current version of fedbalancer do not support:
- Advanced trainer selection with Oort proposed in FedBalancer
- Other FL modes: hybrid, hierarchical

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
