### PR TITLE
fix: missing delta weights computation in middle aggregator

### DIFF
--- a/lib/python/flame/examples/hier_mnist/middle_aggregator/config_uk.json
+++ b/lib/python/flame/examples/hier_mnist/middle_aggregator/config_uk.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us/west/org1",
+        "param-channel": "uk",
         "global-channel": "default"
     },
     "channels": [
@@ -45,8 +45,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us/west/org1",
-                    "default/uk/london/org2"
+                    "uk",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -85,13 +85,13 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "default",
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/uk/london/org2/flame",
+    "realm": "default-cluster",
     "role": "middle-aggregator"
 }

--- a/lib/python/flame/examples/hier_mnist/middle_aggregator/config_us.json
+++ b/lib/python/flame/examples/hier_mnist/middle_aggregator/config_us.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us/west/org1",
+        "param-channel": "us",
         "global-channel": "default"
     },
     "channels": [
@@ -45,8 +45,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us/west/org1",
-                    "default/uk/london/org2"
+                    "uk",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -85,13 +85,13 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "default",
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/us/west/org1/flame",
+    "realm": "default-cluster",
     "role": "middle-aggregator"
 }

--- a/lib/python/flame/examples/hier_mnist/trainer/config_uk.json
+++ b/lib/python/flame/examples/hier_mnist/trainer/config_uk.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us/west/org1"
+        "param-channel": "uk"
     },
     "channels": [
         {
@@ -20,8 +20,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us/west/org1",
-                    "default/uk/london/org2"
+                    "uk",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -60,13 +60,13 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "default",
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/uk/london/org2/machine1",
+    "realm": "org1-cluster",
     "role": "trainer"
 }

--- a/lib/python/flame/examples/hier_mnist/trainer/config_us.json
+++ b/lib/python/flame/examples/hier_mnist/trainer/config_us.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us/west/org1"
+        "param-channel": "us"
     },
     "channels": [
         {
@@ -20,8 +20,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us/west/org1",
-                    "default/uk/london/org2"
+                    "uk",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -67,6 +67,6 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/us/west/org1/machine1",
+    "realm": "org2-cluster",
     "role": "trainer"
 }


### PR DESCRIPTION
## Description

In a hierarchical topology, detla weights computation is not applied in the middle aggregator, which causes loss to increase over rounds. That missing code is applied.

In addition, in the configs for the hier mnist example, groupAssociation values are incorrectly set, which is now fixed.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
