### PR TITLE
fix: incorrect groupAssociation in lib example configs

### DIFF
--- a/lib/python/flame/examples/async_hier_mnist/middle_aggregator/config_uk.json
+++ b/lib/python/flame/examples/async_hier_mnist/middle_aggregator/config_uk.json
@@ -13,7 +13,7 @@
     ],
     "groupAssociation": {
         "global-channel": "default",
-        "param-channel": "default/us/west/org1"
+        "param-channel": "uk"
     },
     "channels": [
         {
@@ -45,8 +45,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us/west/org1",
-                    "default/uk/london/org2"
+                    "uk",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -87,7 +87,7 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "fedbuff",
@@ -101,6 +101,6 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/uk/london/org2/flame",
+    "realm": "uk-default-cluster",
     "role": "middle-aggregator"
 }

--- a/lib/python/flame/examples/async_hier_mnist/middle_aggregator/config_us.json
+++ b/lib/python/flame/examples/async_hier_mnist/middle_aggregator/config_us.json
@@ -13,7 +13,7 @@
     ],
     "groupAssociation": {
         "global-channel": "default",
-        "param-channel": "default/us/west/org1"
+        "param-channel": "us"
     },
     "channels": [
         {
@@ -45,8 +45,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us/west/org1",
-                    "default/uk/london/org2"
+                    "uk",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -87,7 +87,7 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "fedbuff",
@@ -101,6 +101,6 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/us/west/org1/flame",
+    "realm": "us-default-cluster",
     "role": "middle-aggregator"
 }

--- a/lib/python/flame/examples/async_hier_mnist/trainer/config_uk1.json
+++ b/lib/python/flame/examples/async_hier_mnist/trainer/config_uk1.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us/west/org1"
+        "param-channel": "uk"
     },
     "channels": [
         {
@@ -20,8 +20,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us/west/org1",
-                    "default/uk/london/org2"
+                    "uk",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -62,7 +62,7 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "fedbuff",
@@ -76,6 +76,6 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/uk/london/org2/machine1",
+    "realm": "uk-org1-cluster",
     "role": "trainer"
 }

--- a/lib/python/flame/examples/async_hier_mnist/trainer/config_uk2.json
+++ b/lib/python/flame/examples/async_hier_mnist/trainer/config_uk2.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us/west/org1"
+        "param-channel": "uk"
     },
     "channels": [
         {
@@ -20,8 +20,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us/west/org1",
-                    "default/uk/london/org2"
+                    "uk",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -62,7 +62,7 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "fedbuff",
@@ -76,6 +76,6 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/uk/london/org2/machine2",
+    "realm": "uk-org2-cluster",
     "role": "trainer"
 }

--- a/lib/python/flame/examples/async_hier_mnist/trainer/config_us1.json
+++ b/lib/python/flame/examples/async_hier_mnist/trainer/config_us1.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us/west/org1"
+        "param-channel": "us"
     },
     "channels": [
         {
@@ -20,8 +20,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us/west/org1",
-                    "default/uk/london/org2"
+                    "uk",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -62,7 +62,7 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "fedbuff",
@@ -76,6 +76,6 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/us/west/org1/machine1",
+    "realm": "us-org1-cluster",
     "role": "trainer"
 }

--- a/lib/python/flame/examples/async_hier_mnist/trainer/config_us2.json
+++ b/lib/python/flame/examples/async_hier_mnist/trainer/config_us2.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us/west/org1"
+        "param-channel": "us"
     },
     "channels": [
         {
@@ -20,8 +20,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us/west/org1",
-                    "default/uk/london/org2"
+                    "uk",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -62,7 +62,7 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "fedbuff",
@@ -76,6 +76,6 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/us/west/org1/machine2",
+    "realm": "us-org2-cluster",
     "role": "trainer"
 }

--- a/lib/python/flame/examples/hybrid/trainer/config_eu_org1.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_eu_org1.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us",
+        "param-channel": "eu",
         "global-channel": "default"
     },
     "channels": [
@@ -21,8 +21,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us",
-                    "default/eu"
+                    "eu",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -91,7 +91,7 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/eu/org",
+    "realm": "eu-org-cluster",
     "role": "trainer",
     "channelConfigs": {
         "param-channel": {

--- a/lib/python/flame/examples/hybrid/trainer/config_eu_org2.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_eu_org2.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us",
+        "param-channel": "eu",
         "global-channel": "default"
     },
     "channels": [
@@ -21,8 +21,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us",
-                    "default/eu"
+                    "eu",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -91,7 +91,7 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/eu/org",
+    "realm": "eu-org-cluster",
     "role": "trainer",
     "channelConfigs": {
         "param-channel": {

--- a/lib/python/flame/examples/hybrid/trainer/config_us_org1.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_us_org1.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us",
+        "param-channel": "us",
         "global-channel": "default"
     },
     "channels": [
@@ -21,8 +21,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us",
-                    "default/eu"
+                    "eu",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -91,7 +91,7 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/us/org",
+    "realm": "us-org-cluster",
     "role": "trainer",
     "channelConfigs": {
         "param-channel": {

--- a/lib/python/flame/examples/hybrid/trainer/config_us_org2.json
+++ b/lib/python/flame/examples/hybrid/trainer/config_us_org2.json
@@ -12,7 +12,7 @@
         }
     ],
     "groupAssociation": {
-        "param-channel": "default/us",
+        "param-channel": "us",
         "global-channel": "default"
     },
     "channels": [
@@ -21,8 +21,8 @@
             "groupBy": {
                 "type": "tag",
                 "value": [
-                    "default/us",
-                    "default/eu"
+                    "eu",
+                    "us"
                 ]
             },
             "name": "param-channel",
@@ -91,7 +91,7 @@
         "kwargs": {}
     },
     "maxRunTime": 300,
-    "realm": "default/us/org",
+    "realm": "us-org-cluster",
     "role": "trainer",
     "channelConfigs": {
         "param-channel": {


### PR DESCRIPTION
## Description

In the examples of hybrid fl and hierarchical asynchronous fl, groupAssociation values are incorrectly specified. Hence, these examples didn't work.

The groups in the configs are simplified and groupAssociation values are correctly updated.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
