### PR TITLE
fix: hardening coordinated syncfl

### DIFF
--- a/lib/python/flame/channel.py
+++ b/lib/python/flame/channel.py
@@ -320,7 +320,7 @@ class Channel(object):
 
         runs = []
         for end_id in end_ids:
-            if end_id in self._active_recv_fifo_tasks:
+            if not self.has(end_id) or end_id in self._active_recv_fifo_tasks:
                 continue
             else:
                 runs.append(_get_inner(end_id))

--- a/lib/python/flame/examples/coord_hier_syncfl_mnist/middle_aggregator/config2.json
+++ b/lib/python/flame/examples/coord_hier_syncfl_mnist/middle_aggregator/config2.json
@@ -107,7 +107,7 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "default",

--- a/lib/python/flame/examples/coord_hier_syncfl_mnist/top_aggregator/config.json
+++ b/lib/python/flame/examples/coord_hier_syncfl_mnist/top_aggregator/config.json
@@ -70,7 +70,7 @@
     "hyperparameters": {
         "batchSize": 32,
         "learningRate": 0.01,
-        "rounds": 5
+        "rounds": 10
     },
     "baseModel": {
         "name": "",
@@ -82,7 +82,7 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "default",

--- a/lib/python/flame/examples/coord_hier_syncfl_mnist/trainer/config1.json
+++ b/lib/python/flame/examples/coord_hier_syncfl_mnist/trainer/config1.json
@@ -82,7 +82,7 @@
     },
     "registry": {
         "sort": "dummy",
-        "uri": "http://flame-mlflow:5000"
+        "uri": ""
     },
     "selector": {
         "sort": "default",

--- a/lib/python/flame/mode/horizontal/coord_syncfl/trainer.py
+++ b/lib/python/flame/mode/horizontal/coord_syncfl/trainer.py
@@ -41,11 +41,11 @@ class Trainer(BaseTrainer, metaclass=ABCMeta):
         channel.await_join()
 
         end = channel.one_end()
-        msg = channel.recv(end)
+        msg, _ = channel.recv(end)
 
         if MessageType.COORDINATED_ENDS in msg:
             self.aggregator_id = msg[MessageType.COORDINATED_ENDS]
-            
+
     def _fetch_weights(self, tag: str) -> None:
         logger.debug("calling _fetch_weights")
         channel = self.cm.get_by_tag(tag)
@@ -56,7 +56,7 @@ class Trainer(BaseTrainer, metaclass=ABCMeta):
         # this call waits for at least one peer joins this channel
         channel.await_join()
 
-        msg = channel.recv(self.aggregator_id)
+        msg, _ = channel.recv(self.aggregator_id)
 
         if MessageType.WEIGHTS in msg:
             self.weights = weights_to_model_device(msg[MessageType.WEIGHTS], self.model)

--- a/lib/python/flame/mode/horizontal/middle_aggregator.py
+++ b/lib/python/flame/mode/horizontal/middle_aggregator.py
@@ -20,6 +20,7 @@ from flame.mode.horizontal.syncfl.middle_aggregator import (
     TAG_DISTRIBUTE,
     TAG_FETCH,
     TAG_UPLOAD,
+    WAIT_TIME_FOR_TRAINER,
     MiddleAggregator,
 )
 

--- a/lib/python/flame/mode/horizontal/trainer.py
+++ b/lib/python/flame/mode/horizontal/trainer.py
@@ -16,7 +16,7 @@
 """horizontal FL trainer."""
 
 # pylint: disable=unused-import
-from flame.mode.horizontal.syncfl.trainer import Trainer
+from flame.mode.horizontal.syncfl.trainer import TAG_FETCH, TAG_UPLOAD, Trainer
 
 # Redirect `flame.mode.horizontal.trainer.Trainer` to
 # `flame.mode.horizontal.syncfl.trainer.Trainer


### PR DESCRIPTION
## Description

The current implementation of the coordinated syncfl has some corner cases.

1) Channel property for round is not specified; this causes the default selector to ignore ends (peers in the other end of channel) who join late.
2) There exists a synchronization issue; the coordinator returns peer information so that middle aggregators and trainers can talk to each other. However, the peer information may not be up to date yet because the actual joining process to the channel between middle aggregators and trainers are not completely.

These are handled in this change.
## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
