### PR TITLE
fix: zero weight upload from trainer in hybrid mode

### DIFF
--- a/lib/python/flame/mode/hybrid/trainer.py
+++ b/lib/python/flame/mode/hybrid/trainer.py
@@ -109,14 +109,13 @@ class Trainer(DistTrainer):
         # one aggregator is sufficient
         end = channel.one_end()
 
-        self._update_weights()
-
         if not self.can_ring_allreduce():
             # ring was not formed; so, all-reduce didn't take a place.
             # in such a case, each worker should follow the conventional
             # fl procedure by sharing  their local model weights with
             # an aggregator.
             logger.debug("ring was not formed; each shares its weights")
+            self._update_weights()
             weights, size = self.weights, self.dataset_size
 
         # reaching here means that all-reduce took place. So, a committer


### PR DESCRIPTION
remove _update_weights() call from _upload_weights() function before calculating the delta weights, as such a function call makes self.prev_weights and self.weights equal, resulting in delta_weights to be all zero

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
