### PR TITLE
feat: optimize composer's extensibility

### DIFF
--- a/lib/python/flame/mode/distributed/trainer.py
+++ b/lib/python/flame/mode/distributed/trainer.py
@@ -20,9 +20,10 @@ import logging
 from collections import OrderedDict
 from copy import deepcopy
 
-from ...channel_manager import ChannelManager
-from ...common.custom_abcmeta import ABCMeta, abstract_attribute
-from ...common.util import (
+from flame.channel_manager import ChannelManager
+from flame.common.constants import DeviceType
+from flame.common.custom_abcmeta import ABCMeta, abstract_attribute
+from flame.common.util import (
     MLFramework,
     delta_weights_pytorch,
     delta_weights_tensorflow,
@@ -32,13 +33,12 @@ from ...common.util import (
     weights_to_device,
     weights_to_model_device,
 )
-from ...common.constants import DeviceType
-from ...registries import registry_provider
-from ..composer import Composer
-from ..message import MessageType
-from ..role import Role
-from ..tasklet import Loop, Tasklet
-from ...config import Config
+from flame.config import Config
+from flame.mode.composer import Composer
+from flame.mode.message import MessageType
+from flame.mode.role import Role
+from flame.mode.tasklet import Loop, Tasklet
+from flame.registries import registry_provider
 
 logger = logging.getLogger(__name__)
 
@@ -489,27 +489,27 @@ class Trainer(Role, metaclass=ABCMeta):
         with Composer() as composer:
             self.composer = composer
 
-            task_init_cm = Tasklet(self.init_cm)
+            task_init_cm = Tasklet("", self.init_cm)
 
-            task_internal_init = Tasklet(self.internal_init)
+            task_internal_init = Tasklet("", self.internal_init)
 
-            task_load_data = Tasklet(self.load_data)
+            task_load_data = Tasklet("", self.load_data)
 
-            task_init = Tasklet(self.initialize)
+            task_init = Tasklet("", self.initialize)
 
-            task_allreduce = Tasklet(self._ring_allreduce, TAG_RING_ALLREDUCE)
+            task_allreduce = Tasklet("", self._ring_allreduce, TAG_RING_ALLREDUCE)
 
-            task_train = Tasklet(self.train)
+            task_train = Tasklet("", self.train)
 
-            task_eval = Tasklet(self.evaluate)
+            task_eval = Tasklet("", self.evaluate)
 
-            task_increment_round = Tasklet(self.increment_round)
+            task_increment_round = Tasklet("", self.increment_round)
 
-            task_save_metrics = Tasklet(self.save_metrics)
+            task_save_metrics = Tasklet("", self.save_metrics)
 
-            task_save_params = Tasklet(self.save_params)
+            task_save_params = Tasklet("", self.save_params)
 
-            task_save_model = Tasklet(self.save_model)
+            task_save_model = Tasklet("", self.save_model)
 
             # create a loop object with loop exit condition function
             loop = Loop(loop_check_fn=lambda: self._work_done)

--- a/lib/python/flame/mode/horizontal/coord_syncfl/coordinator.py
+++ b/lib/python/flame/mode/horizontal/coord_syncfl/coordinator.py
@@ -168,17 +168,17 @@ class Coordinator(Role):
         with Composer() as composer:
             self.composer = composer
 
-            task_check_eot = Tasklet(self.check_eot)
+            task_check_eot = Tasklet("", self.check_eot)
 
-            task_await = Tasklet(self.await_mid_aggs_and_trainers)
+            task_await = Tasklet("", self.await_mid_aggs_and_trainers)
 
-            task_pairing = Tasklet(self.pair_mid_aggs_and_trainers)
+            task_pairing = Tasklet("", self.pair_mid_aggs_and_trainers)
 
-            task_send_trainers_to_agg = Tasklet(self.send_selected_trainers)
+            task_send_trainers_to_agg = Tasklet("", self.send_selected_trainers)
 
-            task_send_agg_to_trainer = Tasklet(self.send_selected_aggregator)
+            task_send_agg_to_trainer = Tasklet("", self.send_selected_aggregator)
 
-            task_graceful_exit = Tasklet(self.graceful_exit)
+            task_graceful_exit = Tasklet("", self.graceful_exit)
 
         loop = Loop(loop_check_fn=lambda: self._work_done)
         (

--- a/lib/python/flame/mode/horizontal/coord_syncfl/middle_aggregator.py
+++ b/lib/python/flame/mode/horizontal/coord_syncfl/middle_aggregator.py
@@ -19,14 +19,14 @@ import time
 from copy import deepcopy
 
 from flame.mode.composer import Composer
-from flame.mode.horizontal.middle_aggregator import (
+from flame.mode.horizontal.syncfl.middle_aggregator import (
     TAG_AGGREGATE,
     TAG_DISTRIBUTE,
     TAG_FETCH,
     TAG_UPLOAD,
     WAIT_TIME_FOR_TRAINER,
 )
-from flame.mode.horizontal.middle_aggregator import (
+from flame.mode.horizontal.syncfl.middle_aggregator import (
     MiddleAggregator as BaseMiddleAggregator,
 )
 from flame.mode.message import MessageType
@@ -146,28 +146,28 @@ class MiddleAggregator(BaseMiddleAggregator):
         with Composer() as composer:
             self.composer = composer
 
-            task_internal_init = Tasklet(self.internal_init)
+            task_internal_init = Tasklet("", self.internal_init)
 
-            task_init = Tasklet(self.initialize)
+            task_init = Tasklet("", self.initialize)
 
-            task_load_data = Tasklet(self.load_data)
+            task_load_data = Tasklet("", self.load_data)
 
-            task_get_trainers = Tasklet(self.get, TAG_GET_TRAINERS)
+            task_get_trainers = Tasklet("", self.get, TAG_GET_TRAINERS)
 
-            task_put_dist = Tasklet(self.put, TAG_DISTRIBUTE)
+            task_put_dist = Tasklet("", self.put, TAG_DISTRIBUTE)
             task_put_dist.set_continue_fn(cont_fn=lambda: self.trainer_no_show)
 
-            task_put_upload = Tasklet(self.put, TAG_UPLOAD)
+            task_put_upload = Tasklet("", self.put, TAG_UPLOAD)
 
-            task_get_aggr = Tasklet(self.get, TAG_AGGREGATE)
+            task_get_aggr = Tasklet("", self.get, TAG_AGGREGATE)
 
-            task_get_fetch = Tasklet(self.get, TAG_FETCH)
+            task_get_fetch = Tasklet("", self.get, TAG_FETCH)
 
-            task_eval = Tasklet(self.evaluate)
+            task_eval = Tasklet("", self.evaluate)
 
-            task_update_round = Tasklet(self.update_round)
+            task_update_round = Tasklet("", self.update_round)
 
-            task_end_of_training = Tasklet(self.inform_end_of_training)
+            task_end_of_training = Tasklet("", self.inform_end_of_training)
 
         loop = Loop(loop_check_fn=lambda: self._work_done)
         (

--- a/lib/python/flame/mode/horizontal/coord_syncfl/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/coord_syncfl/top_aggregator.py
@@ -17,8 +17,10 @@
 import logging
 
 from flame.mode.composer import Composer
-from flame.mode.horizontal.top_aggregator import TAG_AGGREGATE, TAG_DISTRIBUTE
-from flame.mode.horizontal.top_aggregator import TopAggregator as BaseTopAggregator
+from flame.mode.horizontal.syncfl.top_aggregator import TAG_AGGREGATE, TAG_DISTRIBUTE
+from flame.mode.horizontal.syncfl.top_aggregator import (
+    TopAggregator as BaseTopAggregator,
+)
 from flame.mode.message import MessageType
 from flame.mode.tasklet import Loop, Tasklet
 
@@ -56,33 +58,33 @@ class TopAggregator(BaseTopAggregator):
         with Composer() as composer:
             self.composer = composer
 
-            task_internal_init = Tasklet(self.internal_init)
+            task_internal_init = Tasklet("", self.internal_init)
 
-            task_init = Tasklet(self.initialize)
+            task_init = Tasklet("", self.initialize)
 
-            task_load_data = Tasklet(self.load_data)
+            task_load_data = Tasklet("", self.load_data)
 
-            task_notify_coord = Tasklet(self.notify_coordinator)
+            task_notify_coord = Tasklet("", self.notify_coordinator)
 
-            task_put = Tasklet(self.put, TAG_DISTRIBUTE)
+            task_put = Tasklet("", self.put, TAG_DISTRIBUTE)
 
-            task_get = Tasklet(self.get, TAG_AGGREGATE)
+            task_get = Tasklet("", self.get, TAG_AGGREGATE)
 
-            task_train = Tasklet(self.train)
+            task_train = Tasklet("", self.train)
 
-            task_eval = Tasklet(self.evaluate)
+            task_eval = Tasklet("", self.evaluate)
 
-            task_analysis = Tasklet(self.run_analysis)
+            task_analysis = Tasklet("", self.run_analysis)
 
-            task_save_metrics = Tasklet(self.save_metrics)
+            task_save_metrics = Tasklet("", self.save_metrics)
 
-            task_increment_round = Tasklet(self.increment_round)
+            task_increment_round = Tasklet("", self.increment_round)
 
-            task_end_of_training = Tasklet(self.inform_end_of_training)
+            task_end_of_training = Tasklet("", self.inform_end_of_training)
 
-            task_save_params = Tasklet(self.save_params)
+            task_save_params = Tasklet("", self.save_params)
 
-            task_save_model = Tasklet(self.save_model)
+            task_save_model = Tasklet("", self.save_model)
 
         # create a loop object with loop exit condition function
         loop = Loop(loop_check_fn=lambda: self._work_done)

--- a/lib/python/flame/mode/horizontal/coord_syncfl/trainer.py
+++ b/lib/python/flame/mode/horizontal/coord_syncfl/trainer.py
@@ -20,8 +20,8 @@ from abc import ABCMeta
 from flame.common.constants import DeviceType, TrainerState
 from flame.common.util import weights_to_device, weights_to_model_device
 from flame.mode.composer import Composer
-from flame.mode.horizontal.trainer import TAG_FETCH, TAG_UPLOAD
-from flame.mode.horizontal.trainer import Trainer as BaseTrainer
+from flame.mode.horizontal.syncfl.trainer import TAG_FETCH, TAG_UPLOAD
+from flame.mode.horizontal.syncfl.trainer import Trainer as BaseTrainer
 from flame.mode.message import MessageType
 from flame.mode.tasklet import Loop, Tasklet
 
@@ -101,23 +101,23 @@ class Trainer(BaseTrainer, metaclass=ABCMeta):
         with Composer() as composer:
             self.composer = composer
 
-            task_internal_init = Tasklet(self.internal_init)
+            task_internal_init = Tasklet("", self.internal_init)
 
-            task_load_data = Tasklet(self.load_data)
+            task_load_data = Tasklet("", self.load_data)
 
-            task_init = Tasklet(self.initialize)
+            task_init = Tasklet("", self.initialize)
 
-            task_get_aggregator = Tasklet(self._get_aggregator)
+            task_get_aggregator = Tasklet("", self._get_aggregator)
 
-            task_get = Tasklet(self.get, TAG_FETCH)
+            task_get = Tasklet("", self.get, TAG_FETCH)
 
-            task_train = Tasklet(self.train)
+            task_train = Tasklet("", self.train)
 
-            task_eval = Tasklet(self.evaluate)
+            task_eval = Tasklet("", self.evaluate)
 
-            task_put = Tasklet(self.put, TAG_UPLOAD)
+            task_put = Tasklet("", self.put, TAG_UPLOAD)
 
-            task_save_metrics = Tasklet(self.save_metrics)
+            task_save_metrics = Tasklet("", self.save_metrics)
 
             # create a loop object with loop exit condition function
             loop = Loop(loop_check_fn=lambda: self._work_done)

--- a/lib/python/flame/mode/horizontal/oort/trainer.py
+++ b/lib/python/flame/mode/horizontal/oort/trainer.py
@@ -16,17 +16,18 @@
 """Oort horizontal FL top level aggregator."""
 
 import logging
-import torch
 import math
 from typing import Callable
 
-from ....channel import VAL_CH_STATE_SEND
-from ....common.util import weights_to_device
-from ....common.constants import DeviceType
-from ...composer import Composer
-from ...message import MessageType
-from ...tasklet import Loop, Tasklet
-from ..trainer import Trainer as BaseTrainer, TAG_FETCH, TAG_UPLOAD
+import torch
+from flame.channel import VAL_CH_STATE_SEND
+from flame.common.constants import DeviceType
+from flame.common.util import weights_to_device
+from flame.mode.composer import Composer
+from flame.mode.horizontal.syncfl.trainer import TAG_FETCH, TAG_UPLOAD
+from flame.mode.horizontal.syncfl.trainer import Trainer as BaseTrainer
+from flame.mode.message import MessageType
+from flame.mode.tasklet import Loop, Tasklet
 
 logger = logging.getLogger(__name__)
 
@@ -112,23 +113,23 @@ class Trainer(BaseTrainer):
         with Composer() as composer:
             self.composer = composer
 
-            task_internal_init = Tasklet(self.internal_init)
+            task_internal_init = Tasklet("", self.internal_init)
 
-            task_init_oort_variables = Tasklet(self.init_oort_variables)
+            task_init_oort_variables = Tasklet("", self.init_oort_variables)
 
-            task_load_data = Tasklet(self.load_data)
+            task_load_data = Tasklet("", self.load_data)
 
-            task_init = Tasklet(self.initialize)
+            task_init = Tasklet("", self.initialize)
 
-            task_get = Tasklet(self.get, TAG_FETCH)
+            task_get = Tasklet("", self.get, TAG_FETCH)
 
-            task_train = Tasklet(self.train)
+            task_train = Tasklet("", self.train)
 
-            task_eval = Tasklet(self.evaluate)
+            task_eval = Tasklet("", self.evaluate)
 
-            task_put = Tasklet(self.put, TAG_UPLOAD)
+            task_put = Tasklet("", self.put, TAG_UPLOAD)
 
-            task_save_metrics = Tasklet(self.save_metrics)
+            task_save_metrics = Tasklet("", self.save_metrics)
 
             # create a loop object with loop exit condition function
             loop = Loop(loop_check_fn=lambda: self._work_done)

--- a/lib/python/flame/mode/horizontal/syncfl/middle_aggregator.py
+++ b/lib/python/flame/mode/horizontal/syncfl/middle_aggregator.py
@@ -261,26 +261,26 @@ class MiddleAggregator(Role, metaclass=ABCMeta):
         with Composer() as composer:
             self.composer = composer
 
-            task_internal_init = Tasklet(self.internal_init)
+            task_internal_init = Tasklet("", self.internal_init)
 
-            task_init = Tasklet(self.initialize)
+            task_init = Tasklet("", self.initialize)
 
-            task_load_data = Tasklet(self.load_data)
+            task_load_data = Tasklet("", self.load_data)
 
-            task_put_dist = Tasklet(self.put, TAG_DISTRIBUTE)
+            task_put_dist = Tasklet("", self.put, TAG_DISTRIBUTE)
             task_put_dist.set_continue_fn(cont_fn=lambda: self.trainer_no_show)
 
-            task_put_upload = Tasklet(self.put, TAG_UPLOAD)
+            task_put_upload = Tasklet("", self.put, TAG_UPLOAD)
 
-            task_get_aggr = Tasklet(self.get, TAG_AGGREGATE)
+            task_get_aggr = Tasklet("", self.get, TAG_AGGREGATE)
 
-            task_get_fetch = Tasklet(self.get, TAG_FETCH)
+            task_get_fetch = Tasklet("", self.get, TAG_FETCH)
 
-            task_eval = Tasklet(self.evaluate)
+            task_eval = Tasklet("", self.evaluate)
 
-            task_update_round = Tasklet(self.update_round)
+            task_update_round = Tasklet("", self.update_round)
 
-            task_end_of_training = Tasklet(self.inform_end_of_training)
+            task_end_of_training = Tasklet("", self.inform_end_of_training)
 
         # create a loop object with loop exit condition function
         loop = Loop(loop_check_fn=lambda: self._work_done)

--- a/lib/python/flame/mode/horizontal/syncfl/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/syncfl/top_aggregator.py
@@ -267,31 +267,33 @@ class TopAggregator(Role, metaclass=ABCMeta):
         with Composer() as composer:
             self.composer = composer
 
-            task_internal_init = Tasklet(self.internal_init)
+            task_internal_init = Tasklet("internal_init", self.internal_init)
 
-            task_init = Tasklet(self.initialize)
+            task_init = Tasklet("initialize", self.initialize)
 
-            task_load_data = Tasklet(self.load_data)
+            task_load_data = Tasklet("load_data", self.load_data)
 
-            task_put = Tasklet(self.put, TAG_DISTRIBUTE)
+            task_put = Tasklet("distribute", self.put, TAG_DISTRIBUTE)
 
-            task_get = Tasklet(self.get, TAG_AGGREGATE)
+            task_get = Tasklet("aggregate", self.get, TAG_AGGREGATE)
 
-            task_train = Tasklet(self.train)
+            task_train = Tasklet("train", self.train)
 
-            task_eval = Tasklet(self.evaluate)
+            task_eval = Tasklet("evaluate", self.evaluate)
 
-            task_analysis = Tasklet(self.run_analysis)
+            task_analysis = Tasklet("analysis", self.run_analysis)
 
-            task_save_metrics = Tasklet(self.save_metrics)
+            task_save_metrics = Tasklet("save_metrics", self.save_metrics)
 
-            task_increment_round = Tasklet(self.increment_round)
+            task_increment_round = Tasklet("inc_round", self.increment_round)
 
-            task_end_of_training = Tasklet(self.inform_end_of_training)
+            task_end_of_training = Tasklet(
+                "inform_end_of_training", self.inform_end_of_training
+            )
 
-            task_save_params = Tasklet(self.save_params)
+            task_save_params = Tasklet("save_params", self.save_params)
 
-            task_save_model = Tasklet(self.save_model)
+            task_save_model = Tasklet("save_model", self.save_model)
 
         # create a loop object with loop exit condition function
         loop = Loop(loop_check_fn=lambda: self._work_done)

--- a/lib/python/flame/mode/horizontal/syncfl/trainer.py
+++ b/lib/python/flame/mode/horizontal/syncfl/trainer.py
@@ -192,21 +192,21 @@ class Trainer(Role, metaclass=ABCMeta):
         with Composer() as composer:
             self.composer = composer
 
-            task_internal_init = Tasklet(self.internal_init)
+            task_internal_init = Tasklet("", self.internal_init)
 
-            task_load_data = Tasklet(self.load_data)
+            task_load_data = Tasklet("", self.load_data)
 
-            task_init = Tasklet(self.initialize)
+            task_init = Tasklet("", self.initialize)
 
-            task_get = Tasklet(self.get, TAG_FETCH)
+            task_get = Tasklet("", self.get, TAG_FETCH)
 
-            task_train = Tasklet(self.train)
+            task_train = Tasklet("", self.train)
 
-            task_eval = Tasklet(self.evaluate)
+            task_eval = Tasklet("", self.evaluate)
 
-            task_put = Tasklet(self.put, TAG_UPLOAD)
+            task_put = Tasklet("", self.put, TAG_UPLOAD)
 
-            task_save_metrics = Tasklet(self.save_metrics)
+            task_save_metrics = Tasklet("", self.save_metrics)
 
             # create a loop object with loop exit condition function
             loop = Loop(loop_check_fn=lambda: self._work_done)

--- a/lib/python/flame/mode/hybrid/trainer.py
+++ b/lib/python/flame/mode/hybrid/trainer.py
@@ -18,13 +18,13 @@
 import logging
 import time
 
-from ...channel_manager import ChannelManager
-from ...mode.distributed.trainer import Trainer as DistTrainer
-from ...common.util import weights_to_device, weights_to_model_device
-from ...common.constants import DeviceType
-from ..composer import Composer
-from ..message import MessageType
-from ..tasklet import Loop, Tasklet
+from flame.channel_manager import ChannelManager
+from flame.common.constants import DeviceType
+from flame.common.util import weights_to_device, weights_to_model_device
+from flame.mode.composer import Composer
+from flame.mode.distributed.trainer import Trainer as DistTrainer
+from flame.mode.message import MessageType
+from flame.mode.tasklet import Loop, Tasklet
 
 logger = logging.getLogger(__name__)
 
@@ -147,29 +147,29 @@ class Trainer(DistTrainer):
         with Composer() as composer:
             self.composer = composer
 
-            task_init_cm = Tasklet(self.init_cm)
+            task_init_cm = Tasklet("", self.init_cm)
 
-            task_internal_init = Tasklet(self.internal_init)
+            task_internal_init = Tasklet("", self.internal_init)
 
-            task_load_data = Tasklet(self.load_data)
+            task_load_data = Tasklet("", self.load_data)
 
-            task_init = Tasklet(self.initialize)
+            task_init = Tasklet("", self.initialize)
 
-            task_get = Tasklet(self.get, TAG_FETCH)
+            task_get = Tasklet("", self.get, TAG_FETCH)
 
-            task_allreduce = Tasklet(self._ring_allreduce, TAG_RING_ALLREDUCE)
+            task_allreduce = Tasklet("", self._ring_allreduce, TAG_RING_ALLREDUCE)
 
-            task_train = Tasklet(self.train)
+            task_train = Tasklet("", self.train)
 
-            task_eval = Tasklet(self.evaluate)
+            task_eval = Tasklet("", self.evaluate)
 
-            task_put = Tasklet(self.put, TAG_UPLOAD)
+            task_put = Tasklet("", self.put, TAG_UPLOAD)
 
-            task_save_metrics = Tasklet(self.save_metrics)
+            task_save_metrics = Tasklet("", self.save_metrics)
 
-            task_save_params = Tasklet(self.save_params)
+            task_save_params = Tasklet("", self.save_params)
 
-            task_save_model = Tasklet(self.save_model)
+            task_save_model = Tasklet("", self.save_model)
 
             # create a loop object with loop exit condition function
             loop = Loop(loop_check_fn=lambda: self._work_done)


### PR DESCRIPTION
## Description

When a class is inherited, the current compose() function doesn't reuse the tasklets created from the parent class. Therefore, a developer needs to create many of the same tasklets so that they can be chained (hence, composed). This duplicates the code.

To avoid this redundancy, the composer is extended such that the parent's tasklets are retrieved with alias used when they were created in the parent class.

To demonstrate this feature, the compose() method of top_aggregator in asyncfl mode is modified. All other examples still follow the old way of duplicating the code. Those can be revised over time.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
