### PR TITLE
Impove tasklet composition extensibility

### DIFF
--- a/lib/python/flame/mode/enums.py
+++ b/lib/python/flame/mode/enums.py
@@ -1,0 +1,9 @@
+from enum import Flag, auto
+
+
+class LoopIndicator(Flag):
+    """LoopIndicator is a flag class that contains loog begin and end flags."""
+
+    NONE = 0
+    BEGIN = auto()
+    END = auto()

--- a/lib/python/flame/mode/horizontal/syncfl/middle_aggregator.py
+++ b/lib/python/flame/mode/horizontal/syncfl/middle_aggregator.py
@@ -148,7 +148,11 @@ class MiddleAggregator(Role, metaclass=ABCMeta):
         for end in channel.ends():
             logger.debug(f"sending weights to {end}")
             channel.send(
-                end, {MessageType.WEIGHTS: self.weights, MessageType.ROUND: self._round}
+                end,
+                {
+                    MessageType.WEIGHTS: self.weights,
+                    MessageType.ROUND: self._round,
+                },
             )
 
     def _aggregate_weights(self, tag: str) -> None:
@@ -274,7 +278,7 @@ class MiddleAggregator(Role, metaclass=ABCMeta):
 
             task_get_aggr = Tasklet("", self.get, TAG_AGGREGATE)
 
-            task_get_fetch = Tasklet("", self.get, TAG_FETCH)
+            task_get_fetch = Tasklet("fetch", self.get, TAG_FETCH)
 
             task_eval = Tasklet("", self.evaluate)
 
@@ -305,5 +309,7 @@ class MiddleAggregator(Role, metaclass=ABCMeta):
 
     @classmethod
     def get_func_tags(cls) -> list[str]:
-        """Return a list of function tags defined in the middle level aggregator role."""
+        """Return a list of function tags defined in the middle
+        level aggregator role.
+        """
         return [TAG_DISTRIBUTE, TAG_AGGREGATE, TAG_FETCH, TAG_UPLOAD]

--- a/lib/python/flame/mode/tasklet.py
+++ b/lib/python/flame/mode/tasklet.py
@@ -18,21 +18,14 @@
 from __future__ import annotations
 
 import logging
-from enum import Flag, auto
 from queue import Queue
 from typing import Callable
 
 from flame.mode.composer import ComposerContext
+from flame.mode.enums import LoopIndicator
 
 logger = logging.getLogger(__name__)
 
-
-class LoopIndicator(Flag):
-    """LoopIndicator is a flag class that contains loog begin and end flags."""
-
-    NONE = 0
-    BEGIN = auto()
-    END = auto()
 
 
 class Tasklet(object):
@@ -179,6 +172,35 @@ class Tasklet(object):
             return False
 
         return self.cont_fn()
+    
+    def update_loop_attrs(self, check_fn=None, state=None, starter=None, ender=None):
+        if check_fn:
+            self.loop_check_fn = check_fn
+        if state is not None:
+            self.loop_state = state
+        if starter:
+            self.loop_starter = starter
+        if ender:
+            self.loop_ender = ender
+
+    def insert_before(self, tasklet: Tasklet) -> None:
+        """Insert a tasklet before another tasklet in the composer."""
+        self.composer.insert(self.alias, tasklet, after=False)
+
+    def insert_after(self, tasklet: Tasklet) -> None:
+        """Insert a tasklet before another tasklet in the composer."""
+        self.composer.insert(self.alias, tasklet, after=True)
+
+    def replace_with(self, tasklet: Tasklet) -> None:
+        """Replace a tasklet with another tasklet in the composer."""
+        self.alias = tasklet.alias
+        self.func = tasklet.func
+        self.args = tasklet.args
+        self.kwargs = tasklet.kwargs
+
+    def remove(self) -> None:
+        """Remove a tasklet from the composer."""
+        self.composer.remove_tasklet(self.alias)
 
 
 class Loop(object):


### PR DESCRIPTION
## Description

This PR improves the extensibility of tasklet composition by allowing the developer to extend the tasklet set on the original `Composer` by declaring new tasklets under `CloneComposer` context and then use the composer to get originally implmented tasklets by alias and perform composition on them. Implemented tasklet/composer operations:
- `insert_before` which inserts a tasklet before the target tasklet
- `insert_after` which inserts a tasklet after the target tasklet
- `replace_with` which replaces the target tasklet with the new tasklet
- `remove` which removes the target tasklet

The implemented operations work with loop edges, except for `remove` which will raise NotImplementedError if the target tasklet has loop edges.

This PR demonstrates the extensibility of tasklet composition by refactoring the existing coord syncfl mode to use the new extensibility (demonstrating the reduction in LOC needed to achieve same results).

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
