### PR TITLE
fix: slow tx task termination

### DIFF
--- a/lib/python/flame/channel.py
+++ b/lib/python/flame/channel.py
@@ -486,10 +486,14 @@ class Channel(object):
             return
 
         rxq = self._ends[end_id].get_rxq()
+        txq = self._ends[end_id].get_txq()
         del self._ends[end_id]
 
         # put bogus data to unblock a get() call
         await rxq.put(EMPTY_PAYLOAD)
+
+        # put bogus data to let tx_task finish
+        await txq.put(EMPTY_PAYLOAD)
 
         if len(self._ends) == 0:
             # clear (or unset) the event


### PR DESCRIPTION
## Description

tx task termination is slow because putting EMPTY_PAYLOAD was never executed. This was because channel.remove(end) is called that end is going to be removed. Hence, the length of channel._ends is always zero. To address the issue, in channel.remove(), puting EMPTY_PAYLOAD into the tx queue is implemented. With this, every time channel.remove() is called, the given end's tx task is safely terminated.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
