### PR TITLE
Fix alias already exists for coord_syncfl

### DIFF
--- a/lib/python/flame/mode/horizontal/coord_syncfl/middle_aggregator.py
+++ b/lib/python/flame/mode/horizontal/coord_syncfl/middle_aggregator.py
@@ -104,9 +104,9 @@ class MiddleAggregator(BaseMiddleAggregator):
         with CloneComposer(self.composer) as composer:
             self.composer = composer
 
-            task_get_trainers = Tasklet("", self._get_trainers)
+            task_get_trainers = Tasklet("get_trainers", self._get_trainers)
 
-            task_no_trainer = Tasklet("", self._handle_no_trainer)
+            task_no_trainer = Tasklet("handle_no_trainer", self._handle_no_trainer)
             task_no_trainer.set_continue_fn(cont_fn=lambda: self.no_trainer)
 
         self.composer.get_tasklet("fetch").insert_before(task_no_trainer)

--- a/lib/python/flame/mode/horizontal/coord_syncfl/trainer.py
+++ b/lib/python/flame/mode/horizontal/coord_syncfl/trainer.py
@@ -108,7 +108,7 @@ class Trainer(BaseTrainer, metaclass=ABCMeta):
         with CloneComposer(self.composer) as composer:
             self.composer = composer
 
-            task_get_aggregator = Tasklet("", self._get_aggregator)
+            task_get_aggregator = Tasklet("get_aggregator", self._get_aggregator)
 
         self.composer.get_tasklet("fetch").insert_before(task_get_aggregator)
 


### PR DESCRIPTION
## Description

Add aliases for clone_compose created tasks for the coord_synfl mode.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
