### PR TITLE
fix: Resolve the get tasks command by job ID to return the expected tasks details of a job

### DIFF
--- a/cmd/flamectl/resources/task/task.go
+++ b/cmd/flamectl/resources/task/task.go
@@ -69,9 +69,10 @@ func Get(params Params) error {
 func GetMany(params Params) error {
 	// construct URL
 	uriMap := map[string]string{
-		constants.ParamUser:  params.User,
-		constants.ParamJobID: params.JobId,
-		constants.ParamLimit: params.Limit,
+		constants.ParamUser:    params.User,
+		constants.ParamJobID:   params.JobId,
+		constants.ParamLimit:   params.Limit,
+		constants.ParamGeneric: "false",
 	}
 	url := restapi.CreateURL(params.Endpoint, restapi.GetTasksInfoEndpoint, uriMap)
 

--- a/pkg/openapi/apiserver/api_jobs_service.go
+++ b/pkg/openapi/apiserver/api_jobs_service.go
@@ -245,9 +245,10 @@ func (s *JobsApiService) GetTaskInfo(ctx context.Context, user string, jobId str
 // GetTasksInfo - Get the info of tasks in a job
 func (s *JobsApiService) GetTasksInfo(ctx context.Context, user string, jobId string, limit int32) (openapi.ImplResponse, error) {
 	uriMap := map[string]string{
-		constants.ParamUser:  user,
-		constants.ParamJobID: jobId,
-		constants.ParamLimit: strconv.Itoa(int(limit)),
+		constants.ParamUser:    user,
+		constants.ParamJobID:   jobId,
+		constants.ParamLimit:   strconv.Itoa(int(limit)),
+		constants.ParamGeneric: "false",
 	}
 	url := restapi.CreateURL(HostEndpoint, restapi.GetTasksInfoEndpoint, uriMap)
 
@@ -266,9 +267,10 @@ func (s *JobsApiService) GetTasksInfo(ctx context.Context, user string, jobId st
 // GetTasksInfoGeneric - Get the info of tasks in a job
 func (s *JobsApiService) GetTasksInfoGeneric(ctx context.Context, user string, jobId string, limit int32) (openapi.ImplResponse, error) {
 	uriMap := map[string]string{
-		constants.ParamUser:  user,
-		constants.ParamJobID: jobId,
-		constants.ParamLimit: strconv.Itoa(int(limit)),
+		constants.ParamUser:    user,
+		constants.ParamJobID:   jobId,
+		constants.ParamLimit:   strconv.Itoa(int(limit)),
+		constants.ParamGeneric: "false",
 	}
 	url := restapi.CreateURL(HostEndpoint, restapi.GetTasksInfoEndpoint, uriMap)
 


### PR DESCRIPTION
## Description

The `flamectl get tasks <job_id>` command was failing with the status code 400 meaning that no tasks were found. 
But what really was happening was that in the URL we forgot to put a required value based on the URL format.
After adding the missing values, the command started to work sa expected

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
