### PR TITLE
feat: communication cost metric collection

### DIFF
--- a/lib/python/flame/monitor/metric_collector.py
+++ b/lib/python/flame/monitor/metric_collector.py
@@ -24,11 +24,19 @@ class MetricCollector:
         """Initialize Metric Collector."""
         self.state_dict = dict()
     
+    def get_key(self, mtype, alias):
+        return f'{mtype}-{alias}'
+    
     def save(self, mtype, alias, value):
         """Saves key-value pair for metric."""
-        key = f'{mtype}-{alias}'
+        key = self.get_key(mtype, alias)
         self.state_dict[key] = value
         logger.debug(f"Saving state_dict[{key}] = {value}")
+    
+    def accumulate(self, mtype, alias, value):
+        key = self.get_key(mtype, alias)
+        self.state_dict[key] = value + self.state_dict.get(key, 0)
+        logger.debug(f"Accumulating metric state_dict[{key}] = {self.state_dict[key]}")
     
     def get(self):
         """Returns the current metrics that were collected and clears the saved dictionary."""


### PR DESCRIPTION
## Description

Metric collection was added for communication costs. This included changes to flame/mode/channel.py to track the sizes of messages and also changes to flame/monitor/metric_collector.py in order to be able to accumulate a metric over the course of a round.

metric_collector.py was also slightly refactored in order to generate keys in a separate class method.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
