### PR TITLE
fix: disable automatic eviction of diskcache at aggregation

### DIFF
--- a/lib/python/flame/mode/horizontal/asyncfl/middle_aggregator.py
+++ b/lib/python/flame/mode/horizontal/asyncfl/middle_aggregator.py
@@ -202,6 +202,7 @@ class MiddleAggregator(SyncMidAgg):
             tres = TrainResult(weights, count, version)
             # save training result from trainer in a disk cache
             self.cache[end] = tres
+            logger.debug(f"received {len(self.cache)} trainer updates in cache")
 
             self._agg_goal_weights = self.optimizer.do(
                 self._agg_goal_weights, self.cache, total=count, version=self._round

--- a/lib/python/flame/mode/horizontal/asyncfl/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/asyncfl/top_aggregator.py
@@ -89,6 +89,7 @@ class TopAggregator(SyncTopAgg):
             tres = TrainResult(weights, count, version)
             # save training result from trainer in a disk cache
             self.cache[end] = tres
+            logger.debug(f"received {len(self.cache)} trainer updates in cache")
 
             self._agg_goal_weights = self.optimizer.do(
                 self._agg_goal_weights, self.cache, total=count, version=self._round

--- a/lib/python/flame/mode/horizontal/feddyn/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/feddyn/top_aggregator.py
@@ -96,6 +96,8 @@ class TopAggregator(BaseTopAggregator):
                 # save training result from trainer in a disk cache
                 self.cache[end] = tres
 
+        logger.debug(f"received {len(self.cache)} trainer updates in cache")
+
         # optimizer conducts optimization (in this case, aggregation)
         global_weights = self.optimizer.do(
             deepcopy(self.cld_weights),

--- a/lib/python/flame/mode/horizontal/oort/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/oort/top_aggregator.py
@@ -105,6 +105,8 @@ class TopAggregator(BaseTopAggregator):
                 if received_end_count == aggr_num:
                     break
 
+        logger.debug(f"received {len(self.cache)} trainer updates in cache")
+
         # optimizer conducts optimization (in this case, aggregation)
         global_weights = self.optimizer.do(
             deepcopy(self.weights), self.cache, total=total

--- a/lib/python/flame/mode/horizontal/syncfl/middle_aggregator.py
+++ b/lib/python/flame/mode/horizontal/syncfl/middle_aggregator.py
@@ -75,7 +75,12 @@ class MiddleAggregator(Role, metaclass=ABCMeta):
         self._round = 1
         self._work_done = False
 
+        # disk cache is used for saving memory in case model is large
+        # automatic eviction of disk cache is disabled with cull_limit 0
         self.cache = Cache()
+        self.cache.reset("size_limit", 1e15)
+        self.cache.reset("cull_limit", 0)
+
         self.dataset_size = 0
 
         # save distribute tag in an instance variable
@@ -181,6 +186,8 @@ class MiddleAggregator(Role, metaclass=ABCMeta):
                 tres = TrainResult(weights, count)
                 # save training result from trainer in a disk cache
                 self.cache[end] = tres
+
+        logger.debug(f"received {len(self.cache)} trainer updates in cache")
 
         # optimizer conducts optimization (in this case, aggregation)
         global_weights = self.optimizer.do(


### PR DESCRIPTION
Python diskcache, which we use for aggregating trainer updates, have its own automatic eviction policy, depending on its size_limit and cull_limit value. Updated it to disable automatic eviction, and added a logger debug line that tells you the number of updates in the cache.

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
