### PR TITLE
fix: GPU/CPU monitoring termination

### DIFF
--- a/lib/python/flame/monitor/metric_collector.py
+++ b/lib/python/flame/monitor/metric_collector.py
@@ -35,10 +35,12 @@ class MetricCollector:
 
         # CPU monitoring
         cpu_thread = threading.Thread(target=self.gather_cpu_stats)
+        cpu_thread.daemon = True
         cpu_thread.start()
 
         # GPU monitoring
         gpu_thread = threading.Thread(target=self.gather_gpu_stats)
+        gpu_thread.daemon = True
         gpu_thread.start()
 
     def gather_gpu_stats(self, interval=1):


### PR DESCRIPTION
## Description

Both threads for CPU and GPU monitoring were set to daemon=True. Previously, they were not terminating with the rest of the process.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
