### PR TITLE
fix: protobuf version error

### DIFF
--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -38,7 +38,7 @@ setup(
         "diskcache",
         "mlflow==2.0.1",
         "paho-mqtt",
-        "protobuf==3.19.5",
+        "protobuf==3.20.3",
         "grpcio==1.51.1",
         "pydantic",
         "gpustat",
@@ -46,13 +46,6 @@ setup(
         "numpy",
     ],
     extras_require={
-        "dev": [
-            "pre-commit",
-            "black",
-            "flake8",
-            "bandit",
-            "mypy",
-            "isort",
-        ],
+        "dev": ["pre-commit", "black", "flake8", "bandit", "mypy", "isort",],
     },
 )


### PR DESCRIPTION
## Description

The protobuf version specified in setup.py leads to an error during installation. Going forward, an upgraded version of tensorflow (2.12.0) is needed for flame.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
