### PR TITLE
feat: local registry timestamp

### DIFF
--- a/lib/python/flame/registry/local.py
+++ b/lib/python/flame/registry/local.py
@@ -23,7 +23,7 @@ import pickle
 from collections import defaultdict
 from pathlib import Path
 import shutil
-
+import time
 
 from flame.common.util import get_ml_framework_in_use, MLFramework
 from flame.config import Hyperparameters
@@ -75,13 +75,14 @@ class LocalRegistryClient(AbstractRegistryClient):
 
     def save_metrics(self, epoch: int, metrics: Optional[dict[str, float]]) -> None:
         """Save metrics in a model registry."""
+        curr_time = time.time()
         for metric in metrics:
             filename = os.path.join(self.registry_path, METRICS, metric)
             exists = os.path.exists(filename)
             with open(filename, "a+") as file:
                 csv_writer = csv.writer(file)
-                csv_writer.writerow(["round", metric]) if not exists else None
-                csv_writer.writerow([epoch, metrics[metric]])
+                csv_writer.writerow(["round", "time", metric]) if not exists else None
+                csv_writer.writerow([epoch, curr_time, metrics[metric]])
 
     def save_params(self, hyperparameters: Optional[Hyperparameters]) -> None:
         """Save hyperparameters in a model registry."""


### PR DESCRIPTION
## Description

The timestamp of when the metric is saved is added as a second column to each per-round metric csv in the local registry.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
