### PR TITLE
refactor: monitoring scope adjustment in deployer

### DIFF
--- a/cmd/deployer/app/resource_handler.go
+++ b/cmd/deployer/app/resource_handler.go
@@ -119,7 +119,7 @@ func NewResourceHandler(cfg *config.Config, computeSpec openapi.ComputeSpec, bIn
 func (r *resourceHandler) Start() {
 	go r.doStart()
 
-	r.monitorJobs()
+	go r.monitorPods()
 }
 
 func (r *resourceHandler) doStart() {


### PR DESCRIPTION
## Description

Deployer monitoring functionality does more than it has to do. Deployer only needs to monitor pod. If pod failed, it needs to send that signal to the control plane. It shouldn't update job's status. Currently, in case of pod failure, it directly updates task's status, which is not ideal, either.

TODO: We need a mechanism to inform the control plane of pod failure separately so that the control plane can make a final update on task's status correctly by combining all the information (whether the task itself failed, which caused pod failure or pod itself couldn't run, hence pod failure).

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
