### PR TITLE
fix: incorrect task status update by deployer

### DIFF
--- a/cmd/deployer/app/resource_handler.go
+++ b/cmd/deployer/app/resource_handler.go
@@ -259,6 +259,10 @@ func (r *resourceHandler) revokeResource(jobId string) (err error) {
 				continue
 			}
 			taskStatuses[taskId] = openapi.AGENT_REVOKE_SUCCESS
+
+			// stop monitoring of task
+			r.dplyr.DeleteTaskFromMonitoring(taskId)
+
 			// 2.delete all the task resource specification files
 			deploymentChartPath := filepath.Join(r.deploymentDirPath, jobId, taskId)
 			removeErr := os.RemoveAll(deploymentChartPath)


### PR DESCRIPTION
## Description

After deployer uninstall pods, it doesn't stop monitoring. Thus, the deployer thinks that pods' status is unknown and updates tasks' status as fail. This bug is fixed.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
