### PR TITLE
fix: check payload before accumulating bytes received

### DIFF
--- a/lib/python/flame/channel.py
+++ b/lib/python/flame/channel.py
@@ -229,8 +229,9 @@ class Channel(object):
             payload = None
             try:
                 payload = await self._ends[end_id].get()
-                # ignore timestamp for measuring bytes received
-                self.mc.accumulate("bytes", "recv", len(payload[0]))
+                if payload:
+                    # ignore timestamp for measuring bytes received
+                    self.mc.accumulate("bytes", "recv", len(payload[0]))
             except KeyError:
                 return None
 
@@ -345,8 +346,9 @@ class Channel(object):
             payload = None
             try:
                 payload = await self._ends[end_id].get()
-                # ignore timestamp for measuring bytes received
-                self.mc.accumulate("bytes", "recv", len(payload[0]))
+                if payload:
+                    # ignore timestamp for measuring bytes received
+                    self.mc.accumulate("bytes", "recv", len(payload[0]))
             except KeyError:
                 yield end_id, None
 


### PR DESCRIPTION
## Description

Aggregators sometimes send empty messages at the end of training. Previously, the trainer would throw an error when attempting to get the number of bytes received from an empty message. This is fixed by checking for an empty payload.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
