### PR TITLE
feat: allow misc field in config file

### DIFF
--- a/lib/python/flame/config.py
+++ b/lib/python/flame/config.py
@@ -20,7 +20,7 @@ import typing as t
 from enum import Enum
 
 from pydantic import BaseModel as pydBaseModel
-from pydantic import Field
+from pydantic import Extra, Field
 
 
 class FlameSchema(pydBaseModel):
@@ -125,7 +125,7 @@ class BaseModel(FlameSchema):
     version: int = Field(default=0)
 
 
-class Hyperparameters(FlameSchema):
+class Hyperparameters(FlameSchema, extra=Extra.allow):
     batch_size: t.Optional[int] = Field(alias="batchSize")
     learning_rate: t.Optional[float] = Field(alias="learningRate")
     weight_decay: t.Optional[float] = Field(alias="weightDecay")


### PR DESCRIPTION
## Description

The field misc (of type dict) was added to the config file so that users can add more hyperparamters that are not otherwise supported in the format.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
