### PR TITLE
fix: incorrect schema for coordinated syncfl example

### DIFF
--- a/examples/syncfl_hier_coord_mnist/schema.json
+++ b/examples/syncfl_hier_coord_mnist/schema.json
@@ -18,6 +18,7 @@
             "description": "It aggregates the updates from middle-aggregator",
             "groupAssociation": [
                 {
+                    "top-agg-coord-channel": "default",
                     "global-channel": "default"
                 }
             ]
@@ -28,6 +29,7 @@
             "description": "It aggregates the updates from trainers",
             "groupAssociation": [
                 {
+                    "middle-agg-coord-channel": "default",
                     "param-channel": "default",
                     "global-channel": "default"
                 }
@@ -39,6 +41,7 @@
             "isDataConsumer": true,
             "groupAssociation": [
                 {
+                    "trainer-coord-channel": "default",
                     "param-channel": "default"
                 }
             ]


### PR DESCRIPTION
## Description

The schema for the coordinated syncfl example misses a key element in groupAssociation. A group association info for a channel between each role and the coodinator is added to fix the issue.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
