### PR TITLE
fix: hybrid FL aggregation process without member check

### DIFF
--- a/lib/python/examples/hybrid/aggregator/main.py
+++ b/lib/python/examples/hybrid/aggregator/main.py
@@ -20,7 +20,7 @@ import logging
 
 from flame.config import Config
 from flame.dataset import Dataset
-from flame.mode.horizontal.top_aggregator import TopAggregator
+from flame.mode.hybrid.top_aggregator import TopAggregator
 from tensorflow import keras
 from tensorflow.keras import layers
 

--- a/lib/python/flame/mode/hybrid/top_aggregator.py
+++ b/lib/python/flame/mode/hybrid/top_aggregator.py
@@ -1,0 +1,187 @@
+# Copyright 2023 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Hybrid FL top level aggregator."""
+
+import logging
+import time
+from datetime import datetime
+from copy import deepcopy
+from typing import Any
+
+from flame.common.util import weights_to_device, weights_to_model_device
+from flame.common.constants import DeviceType
+from flame.optimizer.train_result import TrainResult
+from flame.mode.message import MessageType
+from flame.mode.horizontal.top_aggregator import TopAggregator as BaseTopAggregator
+from flame.mode.horizontal.syncfl.top_aggregator import (
+    PROP_ROUND_START_TIME,
+    PROP_ROUND_END_TIME,
+)
+
+logger = logging.getLogger(__name__)
+
+GROUP_UNIDENTIFIED = "group_unidentified"
+
+
+class TopAggregator(BaseTopAggregator):
+    """Hybrid Top level Aggregator implements an ML aggregation role."""
+
+    def internal_init(self) -> None:
+        """Initialize internal state for role."""
+        self.end_send_to = {}
+        self.end_receive_from = {}
+        self.end_idx = {}
+        self.end_is_committer = {}
+        self.group_ends = {}
+        self.ends_group = {}
+
+        super().internal_init()
+
+    def _aggregate_weights(self, tag: str) -> None:
+        channel = self.cm.get_by_tag(tag)
+        if not channel:
+            return
+
+        total = 0
+        self.group_ends = {}
+        self.ends_group = {}
+
+        # receive local model parameters from trainers
+        for msg, metadata in channel.recv_fifo(channel.ends()):
+            end, timestamp = metadata
+            if not msg:
+                logger.debug(f"No data from {end}; skipping it")
+                continue
+
+            logger.debug(f"received data from {end}")
+            channel.set_end_property(end, PROP_ROUND_END_TIME, (round, timestamp))
+
+            if MessageType.WEIGHTS in msg:
+                weights = weights_to_model_device(msg[MessageType.WEIGHTS], self.model)
+
+            if MessageType.DATASET_SIZE in msg:
+                count = msg[MessageType.DATASET_SIZE]
+
+            if MessageType.DATASAMPLER_METADATA in msg:
+                self.datasampler.handle_metadata_from_trainer(
+                    msg[MessageType.DATASAMPLER_METADATA],
+                    end,
+                    channel,
+                )
+
+            if MessageType.HYBRID_METADATA in msg:
+                group_id = msg[MessageType.HYBRID_METADATA]["group_id"]
+                self.ends_group[end] = group_id
+                if group_id not in self.group_ends:
+                    self.group_ends[group_id] = [end]
+                else:
+                    self.group_ends[group_id].append(end)
+
+            logger.debug(f"{end}'s parameters trained with {count} samples")
+
+            if weights is not None and count > 0:
+                total += count
+                tres = TrainResult(weights, count)
+                # save training result from trainer in a disk cache
+                self.cache[end] = tres
+
+        logger.debug(f"received {len(self.cache)} trainer updates in cache")
+
+        # optimizer conducts optimization (in this case, aggregation)
+        global_weights = self.optimizer.do(
+            deepcopy(self.weights),
+            self.cache,
+            total=total,
+            num_trainers=len(channel.ends()),
+        )
+        if global_weights is None:
+            logger.debug("failed model aggregation")
+            time.sleep(1)
+            return
+
+        # set global weights
+        self.weights = global_weights
+
+        # update model with global weights
+        self._update_model()
+
+    def _distribute_weights(self, tag: str) -> None:
+        channel = self.cm.get_by_tag(tag)
+        if not channel:
+            logger.debug(f"channel not found for tag {tag}")
+            return
+
+        # this call waits for at least one peer to join this channel
+        channel.await_join()
+
+        # before distributing weights, update it from global model
+        self._update_weights()
+
+        selected_ends = channel.ends()
+        datasampler_metadata = self.datasampler.get_metadata(self._round, selected_ends)
+
+        # find receive_from, send_to, total_count, and is_committer info on all ends
+        self.parse_hybrid_aggregation_info()
+
+        # send out global model parameters to trainers
+        for end in selected_ends:
+            logger.debug(f"sending weights to {end}")
+
+            channel.send(
+                end,
+                {
+                    MessageType.WEIGHTS: weights_to_device(
+                        self.weights, DeviceType.CPU
+                    ),
+                    MessageType.ROUND: self._round,
+                    MessageType.DATASAMPLER_METADATA: datasampler_metadata,
+                    MessageType.HYBRID_METADATA: self.get_hybrid_metadata(end),
+                    MessageType.IS_COMMITTER: self.end_is_committer.get(end),
+                },
+            )
+            # register round start time on each end for round duration measurement.
+            channel.set_end_property(
+                end, PROP_ROUND_START_TIME, (round, datetime.now())
+            )
+
+    def parse_hybrid_aggregation_info(self) -> None:
+        self.end_send_to = {}
+        self.end_receive_from = {}
+        self.end_idx = {}
+        self.end_is_committer = {}
+
+        for group, ends in self.group_ends.items():
+            # Group aggregation not required for one or less trainers
+            if len(ends) > 1:
+                for e_idx, end in enumerate(ends):
+                    self.end_send_to[end] = ends[(e_idx + 1) % len(ends)]
+                    self.end_receive_from[end] = ends[(e_idx - 1) % len(ends)]
+                    self.end_idx[end] = e_idx
+                    self.end_is_committer[end] = (
+                        True if e_idx == len(ends) - 1 else False
+                    )
+
+    def get_hybrid_metadata(self, end) -> dict[str, Any]:
+        group_ends = self.group_ends.get(self.ends_group.get(end))
+        group_size = len(group_ends) if type(group_ends) == list else None
+
+        return {
+            "group_id": self.ends_group.get(end, GROUP_UNIDENTIFIED),
+            "sendto_id": self.end_send_to.get(end),
+            "recvfrom_id": self.end_receive_from.get(end),
+            "rank": self.end_idx.get(end),
+            "size": group_size,
+        }

--- a/lib/python/flame/mode/hybrid/trainer.py
+++ b/lib/python/flame/mode/hybrid/trainer.py
@@ -22,6 +22,7 @@ from flame.common.constants import DeviceType
 from flame.common.util import weights_to_device, weights_to_model_device
 from flame.mode.composer import Composer
 from flame.mode.distributed.trainer import Trainer as DistTrainer
+from flame.mode.hybrid.top_aggregator import GROUP_UNIDENTIFIED
 from flame.mode.message import MessageType
 from flame.mode.tasklet import Loop, Tasklet
 
@@ -56,6 +57,45 @@ class Trainer(DistTrainer):
 
             self.cm.join(ch_name)
 
+    def _member_check(self, tag: str) -> None:
+        """
+        In our HybridFL, ends in the same group communicate to figure out
+        the total_count. Committer end initiates by sending a message in a ring fashion,
+        where ends receiving the message adds its dataset size to it. After one cycle,
+        the committer end, who knows the total count, again sends the message in a
+        ring fashion, to notify all the ends the total count value.
+        """
+        if tag != TAG_RING_ALLREDUCE:
+            return
+
+        channel = self.cm.get_by_tag(tag)
+        if not channel:
+            logger.debug(f"channel not found with tag {tag}")
+            return
+
+        if self.can_ring_allreduce():
+            if self.is_committer:
+                channel.send(self.sendto_id, {MessageType.DATASET_SIZE: 0})
+
+            msg, _ = channel.recv(self.recvfrom_id)
+            aggr_size = msg[MessageType.DATASET_SIZE] + self.dataset_size
+
+            channel.send(self.sendto_id, {MessageType.DATASET_SIZE: aggr_size})
+
+            msg, _ = channel.recv(self.recvfrom_id)
+            aggr_size = msg[MessageType.DATASET_SIZE]
+
+            if not self.is_committer:
+                channel.send(self.sendto_id, {MessageType.DATASET_SIZE: aggr_size})
+
+            self.total_count = aggr_size
+
+        return
+
+    def can_ring_allreduce(self) -> bool:
+        """Return true if a ring is formed for ring-allreduce."""
+        return self.group_identified and self.group_size > 1
+
     def get(self, tag: str) -> None:
         """Get data from remote role(s)."""
         if tag == TAG_FETCH:
@@ -84,6 +124,27 @@ class Trainer(DistTrainer):
 
         if MessageType.ROUND in msg:
             self._round = msg[MessageType.ROUND]
+
+        if MessageType.HYBRID_METADATA in msg:
+            hybrid_metadata = msg[MessageType.HYBRID_METADATA]
+            if (
+                hybrid_metadata["group_id"]
+                == self.config.group_association["param-channel"]
+            ):
+                self.sendto_id = hybrid_metadata["sendto_id"]
+                self.recvfrom_id = hybrid_metadata["recvfrom_id"]
+                self.rank = hybrid_metadata["rank"]
+                self.group_size = hybrid_metadata["size"]
+                self.group_identified = True
+            elif hybrid_metadata["group_id"] == GROUP_UNIDENTIFIED:
+                self.group_identified = False
+            else:
+                raise ValueError(
+                    "group id should be either given or GROUP_UNIDENTIFIED."
+                )
+
+        if MessageType.IS_COMMITTER in msg:
+            self.is_committer = msg[MessageType.IS_COMMITTER]
 
         # once global weights were received, let's join ring channel
         # calling join more than once is okay because channel manager
@@ -138,6 +199,9 @@ class Trainer(DistTrainer):
             MessageType.WEIGHTS: weights_to_device(delta_weights, DeviceType.CPU),
             MessageType.DATASET_SIZE: size,
             MessageType.MODEL_VERSION: self._round,
+            MessageType.HYBRID_METADATA: {
+                "group_id": self.config.group_association["param-channel"]
+            },
         }
         channel.send(end, msg)
 
@@ -155,6 +219,8 @@ class Trainer(DistTrainer):
             task_init = Tasklet("", self.initialize)
 
             task_get = Tasklet("", self.get, TAG_FETCH)
+
+            task_member_check = Tasklet("", self._member_check, TAG_RING_ALLREDUCE)
 
             task_allreduce = Tasklet("", self._ring_allreduce, TAG_RING_ALLREDUCE)
 
@@ -180,6 +246,7 @@ class Trainer(DistTrainer):
                 >> loop(
                     task_get
                     >> task_train
+                    >> task_member_check
                     >> task_allreduce
                     >> task_eval
                     >> task_save_metrics

--- a/lib/python/flame/mode/message.py
+++ b/lib/python/flame/mode/message.py
@@ -50,3 +50,5 @@ class MessageType(Enum):
 
     REQ_COORDINATED_ENDS = 16  # request ends coordinated by a coordinator
     RES_COORDINATED_ENDS = 17  # get ends coordinated by a coordinator
+
+    HYBRID_METADATA = 18  # metadata for hybrid aggregation


### PR DESCRIPTION
changed the hybrid FL's aggregation to not use member check before ring-reduce anymore, instead use the information given by the top-aggregator. To this end, a new top-aggregator is introduced for Hybrid FL, which sends out the information to the ends about which ends to communicate with during ring-reduce.

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
