### PR TITLE
fix: add callback_api_version for Paho MQTT v2.x compatibility

### DIFF
--- a/lib/python/flame/backend/mqtt.py
+++ b/lib/python/flame/backend/mqtt.py
@@ -125,7 +125,7 @@ class MqttBackend(AbstractBackend):
         self._job_id = job_id
         self._id = task_id
 
-        self._mqtt_client = mqtt.Client(self._id, protocol=MQTTv5)
+        self._mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, self._id, protocol=MQTTv5)
 
         self._health_check_topic = f"{MQTT_TOPIC_PREFIX}/{self._job_id}"
 


### PR DESCRIPTION
## Description

Paho MQTT v2.x requires explicit callback_api_version. Without this, instantiating mqtt.Client raises a ValueError. This change ensures compatibility with recent versions of the Paho MQTT library.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
